### PR TITLE
facilitate out of source builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ AM_CONFIG_HEADER([config.h])
 DUNE_CHECK_ALL
 
 # implicitly set the Dune-flags everywhere
-AC_SUBST(AM_CPPFLAGS, $DUNE_CPPFLAGS)
+AC_SUBST(AM_CPPFLAGS, '$(DUNE_CPPFLAGS) -I$(top_srcdir)')
 AC_SUBST(AM_LDFLAGS, $DUNE_LDFLAGS)
 LIBS="$DUNE_LIBS"
 


### PR DESCRIPTION
With this patch we can build dunecommon out of source using the BUILDDIR variable in the opts-file
