### PR TITLE
Amg opt march2012

### DIFF
--- a/dune/upscaling/UpscalerBase.hpp
+++ b/dune/upscaling/UpscalerBase.hpp
@@ -80,9 +80,12 @@ namespace Dune
                   double perm_threshold,
                   double z_tolerance = 0.0,
                   double residual_tolerance = 1e-8,
+                  int linsolver_maxit = 0,
+                  double linsolver_prolongate_factor =1.6,
                   int linsolver_verbosity = 0,
                   int linsolver_type = 1,
-                  bool twodim_hack = false);
+                  bool twodim_hack = false,
+                  int linsolver_smooth_steps=2);
 
 	/// Access the grid.
 	const GridType& grid() const;
@@ -130,8 +133,11 @@ namespace Dune
 	BoundaryConditionType bctype_;
 	bool twodim_hack_;
 	double residual_tolerance_;
+        int linsolver_maxit_;
+        double linsolver_prolongate_factor_;
 	int linsolver_verbosity_;
         int linsolver_type_;
+        int linsolver_smooth_steps_;
 
 	GridType grid_;
 	GridInterface ginterf_;

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -12,6 +12,10 @@ upscale_avg					\
 upscale_cap					\
 upscale_cond					\
 upscale_perm					\
+upscale_relperm_ssor                            \
+upscale_relperm_bgs                             \
+upscale_relperm_aniso                           \
+upscale_relperm_aniso_ssor                      \
 upscale_relperm					\
 upscale_relpermvisc                             \
 upscale_steadystate_implicit
@@ -36,6 +40,18 @@ upscale_cond_SOURCES = upscale_cond.cpp
 upscale_perm_SOURCES = upscale_perm.cpp
 
 upscale_relperm_SOURCES = upscale_relperm.cpp
+
+upscale_relperm_ssor_SOURCES = upscale_relperm.cpp
+upscale_relperm_ssor_CXXFLAGS = -DSMOOTHER_ILU=0 $(AM_CPPFLAGS)
+
+upscale_relperm_bgs_SOURCES = upscale_relperm.cpp
+upscale_relperm_bgs_CXXFLAGS = -DSMOOTHER_ILU=0 -DSMOOTHER_BGS=1 $(AM_CPPFLAGS)
+
+upscale_relperm_aniso_SOURCES = upscale_relperm.cpp
+upscale_relperm_aniso_CXXFLAGS = -DANISOTROPIC_3D=1
+
+upscale_relperm_aniso_ssor_SOURCES = upscale_relperm.cpp
+upscale_relperm_aniso_ssor_CXXFLAGS = -DANISOTROPIC_3D=1 -DSMOOTHER_ILU=0 $(AM_CPPFLAGS)
 
 upscale_relpermvisc_SOURCES = upscale_relpermvisc.cpp
 

--- a/examples/upscale_relperm.cpp
+++ b/examples/upscale_relperm.cpp
@@ -246,6 +246,8 @@ int main(int varnum, char** vararg)
                                                               // give so small contributions near endpoints.
    options.insert(make_pair("linsolver_tolerance", "1e-12"));  // residual tolerance for linear solver
    options.insert(make_pair("linsolver_verbosity", "0"));     // verbosity level for linear solver
+   options.insert(make_pair("linsolver_max_iterations", "0"));         // Maximum number of iterations allow, specify 0 for default
+   options.insert(make_pair("linsolver_prolongate_factor", "1.6")); // Factor to scale the prolongate coarse grid correction,
    options.insert(make_pair("linsolver_type",      "1"));     // type of linear solver: 0 = ILU/BiCGStab, 1 = AMG/CG
    options.insert(make_pair("fluids",              "ow")); // wheater upscaling for oil/water (ow) or gas/oil (go)
    options.insert(make_pair("krowxswirr",          "-1")); // relative permeability in x direction of oil in corresponding oil/water system
@@ -253,7 +255,7 @@ int main(int varnum, char** vararg)
    options.insert(make_pair("krowzswirr",          "-1")); // relative permeability in z direction of oil in corresponding oil/water system
    options.insert(make_pair("doEclipseCheck",      "true")); // Check if minimum relpermvalues in input are zero (specify critical saturations)
    options.insert(make_pair("critRelpermThresh",   "1e-6")); // Threshold for setting minimum relperm to 0 (thus specify critical saturations)
-   
+   options.insert(make_pair("linsolver_smooth_steps", "2")); // Number of pre and postsmoothing steps for AMG
 
    // Conversion factor, multiply mD numbers with this to get m² numbers
    const double milliDarcyToSqMetre = 9.869233e-16;
@@ -941,11 +943,15 @@ int main(int varnum, char** vararg)
    double linsolver_tolerance = atof(options["linsolver_tolerance"].c_str());
    int linsolver_verbosity = atoi(options["linsolver_verbosity"].c_str());
    int linsolver_type = atoi(options["linsolver_type"].c_str());
+   int linsolver_maxit = atoi(options["linsolver_max_iterations"].c_str()); 
+   int smooth_steps = atoi(options["linsolver_smooth_steps"].c_str());
+   double linsolver_prolongate_factor = atof(options["linsolver_prolongate_factor"].c_str());
    bool twodim_hack = false;
    eclParser.convertToSI();
    upscaler.init(eclParser, boundaryCondition,
                  Opm::unit::convert::from(minPerm, Opm::prefix::milli*Opm::unit::darcy),
-                 ztol, linsolver_tolerance, linsolver_verbosity, linsolver_type, twodim_hack);
+                 ztol, linsolver_tolerance, linsolver_maxit, linsolver_prolongate_factor,
+                 linsolver_verbosity, linsolver_type, twodim_hack, smooth_steps);
 
    finish = clock();   timeused_tesselation = (double(finish)-double(start))/CLOCKS_PER_SEC;
    if (isMaster) cout << " (" << timeused_tesselation <<" secs)" << endl;


### PR DESCRIPTION
These patches achieve convergence for the upscaling example given to me. (They are connected and based on the patches to opm-porsol).

The main changes are:
1. Correct treatment of Dirichlet boundary conditions in the code before calling AMG.
2. Made more settings of AMG adjustable, namely maximum number of iterations, the factor used to  
    scale the prolongation and the number of smoothing steps to use,
3. Made SeqOverlappingSchwarz available as a smoother that is essentially a block Gauss-Seidel
    method where the blocks are defined by the aggregates.
