### PR TITLE
Fix elasticity_upscale linking in presence of SuperLU

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -36,7 +36,9 @@ upscale_cond_SOURCES = upscale_cond.cpp
 
 upscale_elasticity_SOURCES = upscale_elasticity.cpp
 upscale_elasticity_CXXFLAGS = ${OPENMP_CXXFLAGS}
-upscale_elasticity_LDADD = $(top_srcdir)/dune/elasticity/libelasticityupscale.la
+upscale_elasticity_LDADD = \
+$(top_srcdir)/dune/elasticity/libelasticityupscale.la \
+$(LDADD)
 
 upscale_perm_SOURCES = upscale_perm.cpp
 


### PR DESCRIPTION
The per-target primary overrides the correspondingly named global
primary.  In the case of '*_LDADD' we need to include the global value
lest we miss SuperLU libraries.
