### PR TITLE
Add eclipse format output to SteadyStateUpscalerImplicit

### DIFF
--- a/dune/upscaling/SteadyStateUpscalerImplicit.hpp
+++ b/dune/upscaling/SteadyStateUpscalerImplicit.hpp
@@ -39,6 +39,7 @@
 #include <dune/upscaling/UpscalerBase.hpp>
 #include <dune/porsol/euler/EulerUpstream.hpp>
 #include <dune/porsol/euler/ImplicitCapillarity.hpp>
+#include <opm/core/GridAdapter.hpp>
 #include <boost/array.hpp>
 
 namespace Dune
@@ -51,7 +52,7 @@ namespace Dune
     class SteadyStateUpscalerImplicit : public UpscalerBase<Traits>
     {
     public:
-	// ------- Typedefs and enums -------
+        // ------- Typedefs and enums -------
 
         typedef UpscalerBase<Traits> Super;
         typedef typename Super::permtensor_t permtensor_t;
@@ -59,32 +60,32 @@ namespace Dune
         typedef typename UpscalerBase<Traits>::GridType GridType;
         enum { Dimension = UpscalerBase<Traits>::Dimension };
 
-	// ------- Methods -------
+        // ------- Methods -------
 
-	/// Default constructor.
-	SteadyStateUpscalerImplicit();
+        /// Default constructor.
+        SteadyStateUpscalerImplicit();
 
-	/// Does a steady-state upscaling.
-	/// @param flow_direction The cardinal direction in which to impose a pressure gradient for the purpose of converging to steady state.
-	/// @param initial_saturation the initial saturation profile for the steady-state computation.
-	/// The vector must have size equal to the number of cells in the grid.
-	/// @param boundary_saturation the saturation of fluid flowing in across the boundary,
-	/// only needed for nonperiodic upscaling.
-	/// @param pressure_drop the pressure drop in Pascal over the domain.
-	/// @param upscaled_perm typically the output of upscaleSinglePhase().
-	/// @return the upscaled relative permeability matrices of both phases.
-	/// The relative permeability matrix, call it k, is such that if K_w is the phase
-	/// permeability and K the absolute permeability, K_w = k*K.
+        /// Does a steady-state upscaling.
+        /// @param flow_direction The cardinal direction in which to impose a pressure gradient for the purpose of converging to steady state.
+        /// @param initial_saturation the initial saturation profile for the steady-state computation.
+        /// The vector must have size equal to the number of cells in the grid.
+        /// @param boundary_saturation the saturation of fluid flowing in across the boundary,
+        /// only needed for nonperiodic upscaling.
+        /// @param pressure_drop the pressure drop in Pascal over the domain.
+        /// @param upscaled_perm typically the output of upscaleSinglePhase().
+        /// @return the upscaled relative permeability matrices of both phases.
+        /// The relative permeability matrix, call it k, is such that if K_w is the phase
+        /// permeability and K the absolute permeability, K_w = k*K.
         std::pair<permtensor_t, permtensor_t> upscaleSteadyState(const int flow_direction,
                                                                  const std::vector<double>& initial_saturation,
                                                                  const double boundary_saturation,
                                                                  const double pressure_drop,
                                                                  const permtensor_t& upscaled_perm,bool& success);
 
-	/// Accessor for the steady state saturation field. This is empty until
-	/// upscaleSteadyState() is called, at which point it will
-	/// contain the last computed (steady) saturation state.
-	const std::vector<double>& lastSaturationState() const;
+        /// Accessor for the steady state saturation field. This is empty until
+        /// upscaleSteadyState() is called, at which point it will
+        /// contain the last computed (steady) saturation state.
+        const std::vector<double>& lastSaturationState() const;
 
         /// Computes the upscaled saturation corresponding to the saturation field
         /// returned by lastSaturationState(). Does this by computing total saturated
@@ -98,32 +99,34 @@ namespace Dune
 
 
     protected:
-	// ------- Typedefs -------
+        // ------- Typedefs -------
    typedef typename Traits::template TransportSolver<GridInterface, typename Super::BCs>::Type TransportSolver;
 
-	// ------- Methods -------
-	template <class FlowSol>
-    void computeInOutFlows(std::pair<double, double>& water_inout,
-                           std::pair<double, double>& oil_inout,
-                           const FlowSol& flow_solution,
-                           const std::vector<double>& saturations) const;
-	/// Override from superclass.
-	virtual void initImpl(const Opm::parameter::ParameterGroup& param);
+        // ------- Methods -------
+        template <class FlowSol>
+        void computeInOutFlows(std::pair<double, double>& water_inout,
+                               std::pair<double, double>& oil_inout,
+                               const FlowSol& flow_solution,
+                               const std::vector<double>& saturations) const;
+        /// Override from superclass.
+        virtual void initImpl(const Opm::parameter::ParameterGroup& param);
 
 
-	// ------- Data members -------
-	std::vector<double> last_saturation_state_;
-	bool output_vtk_;
-    bool print_inoutflows_;
-	int simulation_steps_;
-	double init_stepsize_;
-    double relperm_threshold_;
-    double maximum_mobility_contrast_;
-    double sat_change_year_;
-    int    max_it_;
-    double  max_stepsize_;
-    double dt_sat_tol_;
-	TransportSolver transport_solver_;
+        // ------- Data members -------
+        std::vector<double> last_saturation_state_;
+        bool output_vtk_;
+        bool output_ecl_;
+        bool print_inoutflows_;
+        int simulation_steps_;
+        double init_stepsize_;
+        double relperm_threshold_;
+        double maximum_mobility_contrast_;
+        double sat_change_year_;
+        int    max_it_;
+        double  max_stepsize_;
+        double dt_sat_tol_;
+        TransportSolver transport_solver_;
+        GridAdapter grid_adapter_;
     };
 
 } // namespace Dune


### PR DESCRIPTION
Option activated with output_ecl=true.

Requires libert support in opm-core. If opm-core has not been compiled
with the necessary --with-ert=</usr/local or similar> option, the program
should abort upon trying to write the output. Hopefully this enables to
keep ERT-detection macros and the like out of this module.

Unfortunately some formatting fixes (but only to the header file) makes the changes a little hard to read.
