### PR TITLE
Add dependency to dune-geometry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set (${project}_DEPS
 	# DUNE dependency
 	"dune-common REQUIRED;
 	dune-istl REQUIRED;
+	dune-geometry REQUIRED;
 	dune-grid REQUIRED;
 	opm-core REQUIRED;
 	dune-cornerpoint REQUIRED;


### PR DESCRIPTION
This dependency previously leaked through the dependency to dune-grid.
However, each module should declare its own dependencies properly.

This is similar to OPM/dune-cornerpoint#16
