### PR TITLE
Disable build kluge that is no longer pertinent

### DIFF
--- a/examples/cpchop.cpp
+++ b/examples/cpchop.cpp
@@ -19,8 +19,6 @@
 */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <opm/core/io/eclipse/CornerpointChopper.hpp>
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
 #include <opm/core/utility/MonotCubicInterpolator.hpp>

--- a/examples/cpchop_depthtrend.cpp
+++ b/examples/cpchop_depthtrend.cpp
@@ -18,8 +18,6 @@
 */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 
 #include <opm/core/io/eclipse/CornerpointChopper.hpp>
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>

--- a/examples/cpregularize.cpp
+++ b/examples/cpregularize.cpp
@@ -34,8 +34,6 @@
 */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <opm/core/io/eclipse/CornerpointChopper.hpp>
 #include <opm/core/io/eclipse/EclipseGridParser.hpp>
 #include <opm/core/io/eclipse/EclipseGridInspector.hpp>

--- a/examples/exp_variogram.cpp
+++ b/examples/exp_variogram.cpp
@@ -31,8 +31,6 @@
 */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <opm/core/io/eclipse/CornerpointChopper.hpp>
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
 #include <opm/porsol/common/setupBoundaryConditions.hpp>

--- a/examples/grdecldips.cpp
+++ b/examples/grdecldips.cpp
@@ -19,8 +19,6 @@
 */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <map>
 #include <iostream>
 #include <fstream>

--- a/examples/steadystate_test_implicit.cpp
+++ b/examples/steadystate_test_implicit.cpp
@@ -34,8 +34,6 @@
 */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 
 //#define VERBOSE
 #include <opm/upscaling/SteadyStateUpscalerImplicit.hpp>

--- a/examples/upscale_avg.cpp
+++ b/examples/upscale_avg.cpp
@@ -40,8 +40,6 @@
  */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <iostream>
 #include <fstream>
 #include <sstream>

--- a/examples/upscale_cap.cpp
+++ b/examples/upscale_cap.cpp
@@ -54,8 +54,6 @@
  */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <iostream>
 #include <fstream>
 #include <sstream>

--- a/examples/upscale_cond.cpp
+++ b/examples/upscale_cond.cpp
@@ -51,8 +51,6 @@
  */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <iostream>
 #include <fstream>
 #include <sstream>

--- a/examples/upscale_elasticity.cpp
+++ b/examples/upscale_elasticity.cpp
@@ -13,8 +13,6 @@
 # include "config.h"     
 #endif
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <iostream>
 #include <unistd.h>
 #include <cstring>

--- a/examples/upscale_perm.cpp
+++ b/examples/upscale_perm.cpp
@@ -45,8 +45,6 @@
  */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <iostream>
 #include <fstream>
 #include <sstream>

--- a/examples/upscale_relperm.cpp
+++ b/examples/upscale_relperm.cpp
@@ -59,8 +59,6 @@
  */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <iostream>
 #include <fstream>
 #include <sstream>

--- a/examples/upscale_relpermvisc.cpp
+++ b/examples/upscale_relpermvisc.cpp
@@ -69,8 +69,6 @@
  */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <iostream>
 #include <fstream>
 #include <sstream>

--- a/examples/upscale_singlephase.cpp
+++ b/examples/upscale_singlephase.cpp
@@ -22,8 +22,6 @@
 #include "config.h"
 #endif
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
 #include <opm/core/utility/Units.hpp>
 

--- a/examples/upscale_steadystate_implicit.cpp
+++ b/examples/upscale_steadystate_implicit.cpp
@@ -33,8 +33,6 @@
 */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 
 //#define VERBOSE
 #include <opm/upscaling/SteadyStateUpscalerImplicit.hpp>

--- a/tests/not-unit/aniso_implicit_steadystate_test.cpp
+++ b/tests/not-unit/aniso_implicit_steadystate_test.cpp
@@ -34,8 +34,6 @@
 */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #define VERBOSE
 
 #include <opm/upscaling/SteadyStateUpscalerManager.hpp>

--- a/tests/not-unit/aniso_steadystate_test.cpp
+++ b/tests/not-unit/aniso_steadystate_test.cpp
@@ -34,8 +34,6 @@
 */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 //#define VERBOSE
 
 #include <opm/upscaling/SteadyStateUpscalerManager.hpp>

--- a/tests/not-unit/implicit_steadystate_test.cpp
+++ b/tests/not-unit/implicit_steadystate_test.cpp
@@ -34,8 +34,6 @@
 */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 #define VERBOSE
 
 #include <opm/upscaling/SteadyStateUpscalerManager.hpp>

--- a/tests/not-unit/steadystate_test_explicit.cpp
+++ b/tests/not-unit/steadystate_test_explicit.cpp
@@ -34,8 +34,6 @@
 */
 #include <config.h>
 
-#include <opm/core/utility/have_boost_redef.hpp>
-
 
 //#define VERBOSE
 


### PR DESCRIPTION
The <have_boost_redef.hpp> header was introduced (commit
OPM/opm-core@82369f9) as a work-around for a particular interaction
in the Autotools-based setup of OPM-Core and the Dune core modules.
Notably, Dune's "Enable" trick for Boost failed on some older
Autoconf systems.  Now that we're using CMake, however, that kluge
is no longer needed because OPM-Core always

  #define HAVE_BOOST 1

i.e., as an explict true/false value.

Therefore, we need no longer include <have_boost_redef.hpp> .  The
header will be removed at a later time.
