### PR TITLE
Change marker EXCLUDE_ALL to EXCLUDE_FROM_ALL in opm_compile_satellite

### DIFF
--- a/cmake/Modules/OpmSatellites.cmake
+++ b/cmake/Modules/OpmSatellites.cmake
@@ -28,7 +28,7 @@
 #	                name is also used as name of the target that builds
 #	                all these files.
 #
-#	excl_all        EXCLUDE_ALL if these targets should not be built by
+#	excl_all        EXCLUDE_FROM_ALL if these targets should not be built by
 #	                default, otherwise empty string.
 #
 #	test_regexp     Regular expression which picks the name of a test


### PR DESCRIPTION
Previously, when passing EXCLUDE_ALL to opm_compile_satellite this
resulted a cmake error:

CMake Error at cmake/Modules/UseDebugSymbols.cmake:71 (get_target_property):
  Cannot find source file:

```
EXCLUDE_ALL
```

  Tried extensions .c .C .c++ .cc .cpp .cxx .m .M .mm .h .hh .h++ .hm .hpp
  .hxx .in .txx
Call Stack (most recent call first):
  cmake/Modules/OpmSatellites.cmake:77 (strip_debug_symbols)
  CMakeLists.txt:176 (opm_compile_satellites)
