### PR TITLE
Changed std::tr1 occurences to boost.

### DIFF
--- a/examples/cpregularize.cpp
+++ b/examples/cpregularize.cpp
@@ -111,7 +111,7 @@ int main(int argc, char** argv)
     // Original x/y resolution in terms of coordinate values (not indices)
     Opm::EclipseGridParser gridparser(gridfilename); // TODO: REFACTOR!!!! it is stupid to parse this again
     Opm::EclipseGridInspector gridinspector(gridparser);
-    std::tr1::array<double, 6> gridlimits=gridinspector.getGridLimits();
+    boost::array<double, 6> gridlimits=gridinspector.getGridLimits();
     double finegridxresolution = (gridlimits[1]-gridlimits[0])/dims[0];
     double finegridyresolution = (gridlimits[3]-gridlimits[2])/dims[1];
 

--- a/examples/upscale_avg.cpp
+++ b/examples/upscale_avg.cpp
@@ -217,7 +217,7 @@ int main(int varnum, char** vararg) {
         " x " << griddims[1]+1 << ")" << endl;
     
     // Find max and min in x-, y- and z-directions
-    std::tr1::array<double, 6> gridlimits = eclInspector.getGridLimits();
+    boost::array<double, 6> gridlimits = eclInspector.getGridLimits();
     cout << "                 x-limits: " << gridlimits[0] << " -- " << gridlimits[1] << endl;
     cout << "                 y-limits: " << gridlimits[2] << " -- " << gridlimits[3] << endl;
     cout << "                 z-limits: " << gridlimits[4] << " -- " << gridlimits[5] << endl;


### PR DESCRIPTION
std::tr1 might not be supported by all compilers and will eventually
be dropped by others. Using boost instead makes this more
portable.

I think, this is the last module to update.
