### PR TITLE
Use fastAMG solver as default linear solver for upscaling applications

### DIFF
--- a/examples/upscale_cond.cpp
+++ b/examples/upscale_cond.cpp
@@ -215,6 +215,7 @@ int main(int varnum, char** vararg)
    options.insert(make_pair("linsolver_verbosity", "0"));     // verbosity level for linear solver
    options.insert(make_pair("linsolver_type",      "3"));     // type of linear solver: 0 = ILU/BiCGStab, 1 = AMG/CG, 2 = KAMG/CG, 3 = FastAMG/CG
    options.insert(make_pair("linsolver_prolongate_factor", "1.0")); // Factor to scale the prolongate coarse grid correction
+   options.insert(make_pair("linsolver_smooth_steps", "1")); // Number of pre and postsmoothing steps for AMG
 
    /*
      Extra options for CT-experiments. If you encounter a rock with more than 6

--- a/examples/upscale_perm.cpp
+++ b/examples/upscale_perm.cpp
@@ -100,7 +100,7 @@ int upscale(int varnum, char** vararg) {
     options.insert(make_pair("linsolver_max_iterations", "0"));         // Maximum number of iterations allow, specify 0 for default
     options.insert(make_pair("linsolver_prolongate_factor", "1.0")); // Factor to scale the prolongate coarse grid correction
     options.insert(make_pair("linsolver_type",      "3"));     // type of linear solver: 0 = ILU/BiCGStab, 1 = AMG/CG, 2 = KAMG/CG, 3 = FastAMG/CG
-    options.insert(make_pair("linsolver_smooth_steps", "2")); // Number of pre and postsmoothing steps for AMG
+    options.insert(make_pair("linsolver_smooth_steps", "1")); // Number of pre and postsmoothing steps for AMG
 
     // Parse options from command line
     int eclipseindex = 1; // Index for the eclipsefile in the command line options

--- a/examples/upscale_relperm.cpp
+++ b/examples/upscale_relperm.cpp
@@ -253,7 +253,7 @@ int main(int varnum, char** vararg)
    options.insert(make_pair("krowzswirr",          "-1")); // relative permeability in z direction of oil in corresponding oil/water system
    options.insert(make_pair("doEclipseCheck",      "true")); // Check if minimum relpermvalues in input are zero (specify critical saturations)
    options.insert(make_pair("critRelpermThresh",   "1e-6")); // Threshold for setting minimum relperm to 0 (thus specify critical saturations)
-   options.insert(make_pair("linsolver_smooth_steps", "2")); // Number of pre and postsmoothing steps for AMG
+   options.insert(make_pair("linsolver_smooth_steps", "1")); // Number of pre and postsmoothing steps for AMG
 
    // Conversion factor, multiply mD numbers with this to get m² numbers
    const double milliDarcyToSqMetre = 9.869233e-16;

--- a/examples/upscale_relpermvisc.cpp
+++ b/examples/upscale_relpermvisc.cpp
@@ -234,6 +234,7 @@ int main(int varnum, char** vararg)
     options.insert(make_pair("linsolver_verbosity", "0"));     // verbosity level for linear solver
     options.insert(make_pair("linsolver_type",      "3"));     // type of linear solver: 0 = ILU/BiCGStab, 1 = AMG/CG, 2 = KAMG/CG, 3 = FastAMG/CG
     options.insert(make_pair("linsolver_prolongate_factor", "1.0")); // Factor to scale the prolongate coarse grid correction,
+    options.insert(make_pair("linsolver_smooth_steps", "1")); // Number of pre and postsmoothing steps for AMG
 
     /* Check first if there is anything on the command line to look for */
     if (varnum == 1) {

--- a/opm/upscaling/UpscalerBase.hpp
+++ b/opm/upscaling/UpscalerBase.hpp
@@ -85,7 +85,7 @@ namespace Opm
                   bool twodim_hack = false,
                   int linsolver_maxit = 0,
                   double linsolver_prolongate_factor = 1.0,
-                  int linsolver_smooth_steps = 2);
+                  int linsolver_smooth_steps = 1);
 
 	/// Access the grid.
 	const GridType& grid() const;

--- a/opm/upscaling/UpscalerBase_impl.hpp
+++ b/opm/upscaling/UpscalerBase_impl.hpp
@@ -51,7 +51,7 @@ namespace Opm
 	  linsolver_prolongate_factor_(1.0),
 	  linsolver_verbosity_(0),
           linsolver_type_(3),
-          linsolver_smooth_steps_(2)
+          linsolver_smooth_steps_(1)
     {
     }
 


### PR DESCRIPTION
The fast AMG solver provided by dune-istl and @blattms is tested on realistic cases and shown to be generally faster and more roboust than the previous solver. We therefore set this to default. Documentation on available linear solvers are updated. 
