### PR TITLE
Unconditionally include "config.h"

### DIFF
--- a/examples/upscale_elasticity.cpp
+++ b/examples/upscale_elasticity.cpp
@@ -9,9 +9,8 @@
 //! \brief Elasticity upscaling on cornerpoint grids
 //!
 //==============================================================================
-#ifdef HAVE_CONFIG_H
-# include "config.h"     
-#endif
+
+#include "config.h"
 
 #include <iostream>
 #include <unistd.h>

--- a/examples/upscale_singlephase.cpp
+++ b/examples/upscale_singlephase.cpp
@@ -18,9 +18,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if HAVE_CONFIG_H
 #include "config.h"
-#endif
 
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
 #include <opm/core/utility/Units.hpp>

--- a/opm/elasticity/boundarygrid.cpp
+++ b/opm/elasticity/boundarygrid.cpp
@@ -9,9 +9,8 @@
 //! \brief Class describing 2D quadrilateral grids
 //!
 //==============================================================================
-#ifdef HAVE_CONFIG_H
+
 #include "config.h"
-#endif
 
 #include "boundarygrid.hh"
 

--- a/opm/elasticity/dynmatrixev.cpp
+++ b/opm/elasticity/dynmatrixev.cpp
@@ -1,9 +1,7 @@
 #ifndef DUNE_FMATRIXEIGENVALUES_EXT_CC 
 #define DUNE_FMATRIXEIGENVALUES_EXT_CC 
 
-#ifdef HAVE_CONFIG_H
 #include "config.h"
-#endif
 
 #include <iostream>
 #include <cmath>

--- a/opm/elasticity/fmatrixev_ext.cc
+++ b/opm/elasticity/fmatrixev_ext.cc
@@ -1,9 +1,7 @@
 #ifndef DUNE_FMATRIXEIGENVALUES_EXT_CC 
 #define DUNE_FMATRIXEIGENVALUES_EXT_CC 
 
-#ifdef HAVE_CONFIG_H
 #include "config.h"
-#endif
 
 #include <iostream>
 #include <cmath>


### PR DESCRIPTION
The build system no longer defines HAVE_CONFIG_H so the construct

  #if HAVE_CONFIG_H
  #include "config.h"
  #endif

leads to not including "config.h" at all.
