### PR TITLE
`make check` behaves different from `make ; make check`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,10 @@ macro (fortran_hook)
 endmacro (fortran_hook)
 
 macro (tests_hook)
-	include (${CMAKE_CURRENT_SOURCE_DIR}/TestUpscalingBinaries.cmake)
 endmacro (tests_hook)
 
 # all setup common to the OPM library modules is done here
 include (OpmLibMain)
+
+# setup extra tests (using helper binaries)
+include (${CMAKE_CURRENT_SOURCE_DIR}/TestUpscalingBinaries.cmake)

--- a/TestUpscalingBinaries.cmake
+++ b/TestUpscalingBinaries.cmake
@@ -62,6 +62,11 @@ macro (add_test_upscale_perm gridname bcs rows)
                        run_upscale_perm_BC${bcs}_${gridname})
 endmacro (add_test_upscale_perm gridname bcs)
 
+# Make sure that we build the helper executable before running tests
+# (the "tests" target is setup in OpmLibMain.cmake)
+add_dependencies (tests upscale_perm)
+add_dependencies (tests compare_upscaling_results)
+
 # Add tests for different models
 add_test_upscale_perm(PeriodicTilted p 3)
 add_test_upscale_perm(27cellsAniso flp 9)


### PR DESCRIPTION
This problem does not arise in the other modules, so I suspect `TestUpscalingBinaries.cmake` has something to do with it.
