### PR TITLE
Skip empty lines when comparing upscaling results.

### DIFF
--- a/tests/compare_upscaling_results.cpp
+++ b/tests/compare_upscaling_results.cpp
@@ -57,7 +57,7 @@ Matrix readResultFile(const char* filename, int rows, int cols) {
     int col = 0;
     string line;
     while (getline(resultfile, line)) {
-        if (line[0] == '#') // Skip lines starting with #
+        if (line.empty() || line[0] == '#') // Skip empty lines and lines starting with #
             continue;
         istringstream iss(line);
         while (iss >> value) {


### PR DESCRIPTION
The 'line' obtained from `std::getline()` will be empty if the input
line is blank.  Treat such lines as comments.

Incidentally, this also fixes the tests
- `compare_upscale_elasticity_mpc_EightCells`
- `compare_upscale_elasticity_mortar_EightCells`

when using "libstdc++"'s "debug" mode (`-D_GLIBCXX_DEBUG=1`
`-D_GLIBCXX_DEBUG_PEDANTIC=1`).

This problem was discovered while testing PR #77
