### PR TITLE
fixed: ERT depends on libdl

### DIFF
--- a/cmake/Modules/FindERT.cmake
+++ b/cmake/Modules/FindERT.cmake
@@ -180,6 +180,10 @@ if (UNIX)
 	NAMES "m"
 	)
   list (APPEND ERT_LIBRARIES ${MATH_LIBRARY})
+  find_library (DL_LIBRARY
+	NAMES "dl"
+	)
+  list (APPEND ERT_LIBRARIES ${DL_LIBRARY})
 endif (UNIX)
 
 # since OpenMP often implies pthreads, we need to tidy up


### PR DESCRIPTION
this issue was triggered with static libs for ERT
