### PR TITLE
add missing include of config.h

### DIFF
--- a/tests/compare_upscaling_results.cpp
+++ b/tests/compare_upscaling_results.cpp
@@ -17,6 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "config.h"
+
 #include <string>
 #include <iostream>
 #include <fstream>


### PR DESCRIPTION
this was found by virtue of GCC 4.8 triggering a warning for Dune's
static_assert that should not have been there...
