### PR TITLE
fixed: MPI handling across all apps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include (${project}-prereqs)
 include (CMakeLists_files.cmake)
 
 macro (config_hook)
-	#	opm_need_version_of ("dune-common")
+	opm_need_version_of ("dune-common")
 	list (APPEND ${project}_CONFIG_IMPL_VARS
 		HAVE_LAPACK
 		)

--- a/examples/cpchop.cpp
+++ b/examples/cpchop.cpp
@@ -40,16 +40,12 @@
 #include <cfloat>
 #include <cmath>
 
-#ifdef HAVE_MPI
-#include <mpi.h>
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
+#include <dune/common/parallel/mpihelper.hh>
+#else
+#include <dune/common/mpihelper.hh>
 #endif
-
-void shutdown()
-{
-#ifdef HAVE_MPI
-  MPI_Finalize();
-#endif
-}
 
 int main(int argc, char** argv)
 try
@@ -63,9 +59,8 @@ try
         std::cout << "       [rock_list=] [anisotropicrocks=false]" << std::endl;
         exit(1);
     }
-#ifdef HAVE_MPI
-    MPI_Init(&argc, &argv);
-#endif
+
+    Dune::MPIHelper::instance(argc, argv);
 
     Opm::parameter::ParameterGroup param(argc, argv);
     std::string gridfilename = param.get<std::string>("gridfilename");
@@ -165,7 +160,6 @@ try
                 catch (const char * errormessage) {
                     std::cerr << "Error: " << errormessage << std::endl;
                     std::cerr << "Check filename" << std::endl;
-                    shutdown();
                     exit(1);
                 }
                 
@@ -175,7 +169,6 @@ try
                 }
                 else {
                     std::cerr << "Error: Jfunction " << i+1 << " in rock file " << rockname << " was not invertible." << std::endl;
-                    shutdown();
                     exit(1);
                 }
                 
@@ -196,7 +189,6 @@ try
                 catch (const char * errormessage) {
                     std::cerr << "Error: " << errormessage << std::endl;
                     std::cerr << "Check filename and columns 1 and 2 (Pc and Sw)" << std::endl;
-                    shutdown();
                     exit(1);
                 }
                 if (cappres) {
@@ -206,7 +198,6 @@ try
                     }
                     else {
                         std::cerr << "Error: Pc(Sw) curve " << i+1 << " in rock file " << rockname << " was not invertible." << std::endl;
-                        shutdown();
                         exit(1);
                     }
                 }
@@ -660,11 +651,9 @@ try
 
 
     std::cout << outputtmp.str();
-    shutdown();
 }
 catch (const std::exception &e) {
     std::cerr << "Program threw an exception: " << e.what() << "\n";
-    shutdown();
     throw;
 }
 

--- a/examples/cpchop_depthtrend.cpp
+++ b/examples/cpchop_depthtrend.cpp
@@ -38,6 +38,13 @@
 #include <fstream>
 #include <iostream>
 
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
+#include <dune/common/parallel/mpihelper.hh>
+#else
+#include <dune/common/mpihelper.hh>
+#endif
+
 /**
    This program is a variant of cpchop. Instead of subsampling randomly, 
    it picks subsamples downwards in a model. It is specifically designed
@@ -59,6 +66,8 @@ try
         std::cout << "       [seed=111] [z_tolerance=0.0] [minperm=1e-9] " << std::endl;
         exit(1);
     }
+
+    Dune::MPIHelper::instance(argc, argv);
 
     Opm::parameter::ParameterGroup param(argc, argv);
     std::string gridfilename = param.get<std::string>("gridfilename");

--- a/examples/cpregularize.cpp
+++ b/examples/cpregularize.cpp
@@ -49,6 +49,12 @@
 #include <fstream>
 #include <iostream>
 
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
+#include <dune/common/parallel/mpihelper.hh>
+#else
+#include <dune/common/mpihelper.hh>
+#endif
 
 int main(int argc, char** argv)
 try
@@ -60,6 +66,8 @@ try
         std::cout << "       [resultgrid=regularizedgrid.grdecl]" << std::endl;
         exit(1);
     }
+
+    Dune::MPIHelper::instance(argc, argv);
   
     Opm::parameter::ParameterGroup param(argc, argv);
     std::string gridfilename = param.get<std::string>("gridfilename");

--- a/examples/exp_variogram.cpp
+++ b/examples/exp_variogram.cpp
@@ -50,10 +50,18 @@
 #include <fstream>
 #include <iostream>
 
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
+#include <dune/common/parallel/mpihelper.hh>
+#else
+#include <dune/common/mpihelper.hh>
+#endif
 
 int main(int argc, char** argv)
 try
 {
+    Dune::MPIHelper::instance(argc, argv);
+
     Opm::parameter::ParameterGroup param(argc, argv);
     std::string gridfilename = param.get<std::string>("gridfilename");
     Opm::CornerPointChopper ch(gridfilename);

--- a/examples/grdecldips.cpp
+++ b/examples/grdecldips.cpp
@@ -38,7 +38,12 @@
 #include <opm/porsol/common/setupBoundaryConditions.hpp>
 #include <opm/core/utility/Units.hpp>
 
-
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
+#include <dune/common/parallel/mpihelper.hh>
+#else
+#include <dune/common/mpihelper.hh>
+#endif
 
 using namespace std;
 
@@ -49,6 +54,9 @@ int main(int argc, char** argv) try {
         cout << "       [listallcells=false] [output=filename.txt]" << endl;
         exit(1);
     } 
+
+    Dune::MPIHelper::instance(argc, argv);
+
     Opm::parameter::ParameterGroup param(argc, argv);
     
     std::string gridfilename = param.get<std::string>("gridfilename");

--- a/examples/steadystate_test_implicit.cpp
+++ b/examples/steadystate_test_implicit.cpp
@@ -42,6 +42,14 @@
 #include <opm/porsol/euler/EulerUpstreamImplicit.hpp>
 #include <opm/porsol/common/SimulatorTraits.hpp>
 #include <iostream>
+
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
+#include <dune/common/parallel/mpihelper.hh>
+#else
+#include <dune/common/mpihelper.hh>
+#endif
+
 namespace Opm{
 	template <class IsotropyPolicy>
     struct Implicit
@@ -66,6 +74,8 @@ using namespace Opm;
 int main(int argc, char** argv)
 try
 {
+    Dune::MPIHelper::instance(argc, argv);
+
     // Initialize.
     Opm::parameter::ParameterGroup param(argc, argv);
     // MPIHelper::instance(argc,argv) ;

--- a/examples/upscale_avg.cpp
+++ b/examples/upscale_avg.cpp
@@ -52,6 +52,13 @@
 
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
 
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
+#include <dune/common/parallel/mpihelper.hh>
+#else
+#include <dune/common/mpihelper.hh>
+#endif
+
 using namespace Opm;
 using namespace std;
 
@@ -72,6 +79,8 @@ void usageandexit() {
    @brief Computes simple statistics.
 */
 int main(int varnum, char** vararg) try {        
+
+    Dune::MPIHelper::instance(varnum, vararg);
 
     const double emptycellvolumecutoff = 1e-10;
 

--- a/examples/upscale_cap.cpp
+++ b/examples/upscale_cap.cpp
@@ -67,6 +67,13 @@
 #include <opm/core/utility/MonotCubicInterpolator.hpp>
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
 
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
+#include <dune/common/parallel/mpihelper.hh>
+#else
+#include <dune/common/mpihelper.hh>
+#endif
+
 using namespace Opm;
 using namespace std;
 
@@ -117,6 +124,8 @@ try
     * Step 1:
     * Process command line options
     */
+
+    Dune::MPIHelper::instance(varnum, vararg);
 
    if (varnum == 1) { /* If no arguments supplied ("upscale_cap" is the first ('zero')  "argument") */
       usage();

--- a/examples/upscale_perm.cpp
+++ b/examples/upscale_perm.cpp
@@ -53,7 +53,13 @@
 #include <sys/utsname.h>
 
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
+
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
+#include <dune/common/parallel/mpihelper.hh>
+#else
 #include <dune/common/mpihelper.hh>
+#endif
 
 using namespace std;
 
@@ -83,8 +89,7 @@ void usage() {
    @return int
 */
 int upscale(int varnum, char** vararg) {
-    Dune::MPIHelper& mpi=Dune::MPIHelper::instance(varnum, vararg);
-    mpi.rank();
+    Dune::MPIHelper::instance(varnum, vararg);
     if (varnum ==  1) { // If no arguments supplied ("upscale_perm" is the first argument)
         cout << "Error: No eclipsefile provided" << endl;
         usage();

--- a/examples/upscale_relperm.cpp
+++ b/examples/upscale_relperm.cpp
@@ -69,8 +69,11 @@
 #include <map>
 #include <sys/utsname.h>
 
-#ifdef HAVE_MPI
-#include <mpi.h>
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
+#include <dune/common/parallel/mpihelper.hh>
+#else
+#include <dune/common/mpihelper.hh>
 #endif
 
 #include <opm/core/utility/MonotCubicInterpolator.hpp>
@@ -147,9 +150,6 @@ void usage()
 
 void usageandexit() {
     usage();
-#ifdef HAVE_MPI
-    MPI_Finalize();
-#endif
     exit(1);
 }
 
@@ -207,13 +207,11 @@ try
     * Process command line options
     */
 
-   int mpi_rank = 0;
+   Dune::MPIHelper& mpi=Dune::MPIHelper::instance(varnum, vararg);
+   const int mpi_rank = mpi.rank();
 #ifdef HAVE_MPI
-   int mpi_nodecount = 1;
-   MPI_Init(&varnum, &vararg);
-   MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
-   MPI_Comm_size(MPI_COMM_WORLD, &mpi_nodecount);
-#endif 
+   const int mpi_nodecount = mpi.size();
+#endif
    bool isMaster = (mpi_rank == 0);
    if (varnum == 1) { /* If no arguments supplied ("upscale_relperm" is the first "argument") */
       usage();
@@ -2043,10 +2041,6 @@ try
        }
 
    }
-
-#if HAVE_MPI
-   MPI_Finalize();
-#endif
 
    return 0;
 }

--- a/examples/upscale_singlephase.cpp
+++ b/examples/upscale_singlephase.cpp
@@ -26,6 +26,13 @@
 #include <opm/core/utility/Units.hpp>
 #include <iostream>
 
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
+#include <dune/common/parallel/mpihelper.hh>
+#else
+#include <dune/common/mpihelper.hh>
+#endif
+
 using namespace Opm;
 using namespace Opm::prefix;
 using namespace Opm::unit;
@@ -33,6 +40,8 @@ using namespace Opm::unit;
 int main(int argc, char** argv)
 try
 {
+    Dune::MPIHelper::instance(argc, argv);
+
     Opm::parameter::ParameterGroup param(argc, argv);
     // MPIHelper::instance(argc,argv);
     SinglePhaseUpscaler upscaler;

--- a/examples/upscale_steadystate_implicit.cpp
+++ b/examples/upscale_steadystate_implicit.cpp
@@ -43,6 +43,14 @@
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
 #include <sys/utsname.h>
 #include <iostream>
+
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
+#include <dune/common/parallel/mpihelper.hh>
+#else
+#include <dune/common/mpihelper.hh>
+#endif
+
 namespace Opm{
 	template <class IsotropyPolicy>
     struct Implicit
@@ -173,6 +181,8 @@ std::string toString(T const& value) {
 int main(int argc, char** argv)
 try
 {
+    Dune::MPIHelper::instance(argc, argv);
+
     if (argc == 1) {
         usageandexit();
     }


### PR DESCRIPTION
we need to call mpi_init when compiled against mpi (in particular mpich)
even if running with a single node.

this fixes this across all apps in a uniform way (the dune-intended approach)

@bska please review
