### PR TITLE
Provide explicit definition of EclipseGridInspector

### DIFF
--- a/examples/cpchop.cpp
+++ b/examples/cpchop.cpp
@@ -20,6 +20,7 @@
 #include <config.h>
 
 #include <opm/core/io/eclipse/CornerpointChopper.hpp>
+#include <opm/core/io/eclipse/EclipseGridInspector.hpp>
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
 #include <opm/core/utility/MonotCubicInterpolator.hpp>
 #include <opm/porsol/common/setupBoundaryConditions.hpp>

--- a/examples/upscale_avg.cpp
+++ b/examples/upscale_avg.cpp
@@ -51,6 +51,7 @@
 #include <sys/utsname.h>
 
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
+#include <opm/core/io/eclipse/EclipseGridInspector.hpp>
 
 #include <dune/common/version.hh>
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)


### PR DESCRIPTION
This file uses the "EclipseGridInspector" directly, and should not
rely on indirect includes to provide a valid definition of the
class.
