### PR TITLE
ParserAdditions: Catch up to method rename

### DIFF
--- a/opm/upscaling/ParserAdditions.hpp
+++ b/opm/upscaling/ParserAdditions.hpp
@@ -40,7 +40,7 @@ inline void addNonStandardUpscalingKeywords(Opm::ParserPtr parser)
 
     Json::JsonObject rhoJson(rhoJsonData);
     Opm::ParserKeywordConstPtr rhoKeyword = Opm::ParserKeyword::createFromJson(rhoJson);
-    parser->addKeyword(rhoKeyword);
+    parser->addParserKeyword(rhoKeyword);
 }
 
 }


### PR DESCRIPTION
Commit OPM/opm-parser@ca1733cc renamed the method `Parser::addKeyword()` to `Parser::addParserKeyword()`. Catch up to that renaming to fix the build of opm-upscaling.
