### PR TITLE
Convert all upscaling programs to new pinch behaviour.

### DIFF
--- a/examples/cpchop.cpp
+++ b/examples/cpchop.cpp
@@ -54,7 +54,7 @@ try
     if (argc == 1) {
         std::cout << "Usage: cpchop gridfilename=filename.grdecl [subsamples=10] [ilen=5] [jlen=5] " << std::endl;
         std::cout << "       [zlen=5] [imin=] [imax=] [jmin=] [jmax=] [upscale=true] [bc=fixed]" << std::endl;
-        std::cout << "       [resettoorigin=true] [seed=111] [z_tolerance=0.0] [minperm=1e-9] " << std::endl;
+        std::cout << "       [resettoorigin=true] [seed=111] [minperm=1e-9] " << std::endl;
         std::cout << "       [dips=false] [azimuthdisplacement=] [satnumvolumes=false] [mincellvolume=1e-9]" << std::endl;
         std::cout << "       [filebase=] [resultfile=] [endpoints=false] [cappres=false]" << std::endl;
         std::cout << "       [rock_list=] [anisotropicrocks=false]" << std::endl;
@@ -208,7 +208,9 @@ try
         }
     }
 
-    double z_tolerance = param.getDefault("z_tolerance", 0.0);
+    if (param.has("z_tolerance")) {
+        std::cerr << "****** Warning: z_tolerance parameter is obsolete, use PINCH in deck input instead\n";
+    }
     double residual_tolerance = param.getDefault("residual_tolerance", 1e-8);
     int linsolver_verbosity = param.getDefault("linsolver_verbosity", 0);
 #if DUNE_VERSION_NEWER(DUNE_ISTL, 2, 3) || defined(HAS_DUNE_FAST_AMG)
@@ -318,7 +320,7 @@ try
                 Opm::DeckConstPtr subdeck = ch.subDeck();
                 Opm::SinglePhaseUpscaler upscaler;
                 
-                upscaler.init(subdeck, bctype, minpermSI, z_tolerance,
+                upscaler.init(subdeck, bctype, minpermSI,
                               residual_tolerance, linsolver_verbosity, linsolver_type, false);
 
                 Opm::SinglePhaseUpscaler::permtensor_t upscaled_K = upscaler.upscaleSinglePhase();
@@ -350,7 +352,7 @@ try
                 Opm::DeckConstPtr subdeck = ch.subDeck();
                 std::vector<double>  perms = subdeck->getKeyword("PERMX")->getSIDoubleData();
                 Opm::SinglePhaseUpscaler upscaler;                
-                upscaler.init(subdeck, bctype, minpermSI, z_tolerance,
+                upscaler.init(subdeck, bctype, minpermSI,
                               residual_tolerance, linsolver_verbosity, linsolver_type, false);
                 std::vector<int>   satnums = subdeck->getKeyword("SATNUM")->getIntData();
                 std::vector<double>  poros = subdeck->getKeyword("PORO")->getSIDoubleData();

--- a/examples/cpchop_depthtrend.cpp
+++ b/examples/cpchop_depthtrend.cpp
@@ -63,7 +63,7 @@ try
    if (argc == 1) {
         std::cout << "Usage: cpchop_depthtrend gridfilename=filename.grdecl [zresolution=1] [zlen=1] [ilen=5] [jlen=5] " << std::endl;
         std::cout << "       [zlen=5] [imin=] [imax=] [jmin=] [jmax=] [upscale=true] [resettoorigin=true]" << std::endl;
-        std::cout << "       [seed=111] [z_tolerance=0.0] [minperm=1e-9] " << std::endl;
+        std::cout << "       [seed=111] [minperm=1e-9] " << std::endl;
         exit(1);
     }
 
@@ -97,7 +97,9 @@ try
     double minperm = param.getDefault("minperm", 1e-9);
     double minpermSI = Opm::unit::convert::from(minperm, Opm::prefix::milli*Opm::unit::darcy);
 
-    double z_tolerance = param.getDefault("z_tolerance", 0.0);
+    if (param.has("z_tolerance")) {
+        std::cerr << "****** Warning: z_tolerance parameter is obsolete, use PINCH in deck input instead\n";
+    }
     double residual_tolerance = param.getDefault("residual_tolerance", 1e-8);
     double linsolver_verbosity = param.getDefault("linsolver_verbosity", 0);
     double linsolver_type = param.getDefault("linsolver_type", 1);
@@ -164,7 +166,7 @@ try
             if (upscale) {
                 Opm::DeckConstPtr subdeck = ch.subDeck();
                 Opm::SinglePhaseUpscaler upscaler;
-                upscaler.init(subdeck, Opm::SinglePhaseUpscaler::Fixed, minpermSI, z_tolerance,
+                upscaler.init(subdeck, Opm::SinglePhaseUpscaler::Fixed, minpermSI,
                               residual_tolerance, linsolver_verbosity, linsolver_type, false);
                 
                 Opm::SinglePhaseUpscaler::permtensor_t upscaled_K = upscaler.upscaleSinglePhase();

--- a/examples/cpregularize.cpp
+++ b/examples/cpregularize.cpp
@@ -64,7 +64,7 @@ try
    if (argc == 1) {
         std::cout << "Usage: cpregularize gridfilename=filename.grdecl [ires=5] [jres=5] [zres=5] " << std::endl;
         std::cout << "       [imin=] [imax=] [jmin=] [jmax=] [zmin=] [zmax=] " << std::endl;
-        std::cout << "       [z_tolerance=0.0] [minperm=1e-9] " << std::endl;
+        std::cout << "       [minperm=1e-9] " << std::endl;
         std::cout << "       [resultgrid=regularizedgrid.grdecl]" << std::endl;
         exit(1);
     }
@@ -92,7 +92,9 @@ try
 
     double minperm = param.getDefault("minperm", 1e-9);
     double minpermSI = Opm::unit::convert::from(minperm, Opm::prefix::milli*Opm::unit::darcy);
-    double z_tolerance = param.getDefault("z_tolerance", 1e-8);
+    if (param.has("z_tolerance")) {
+        std::cerr << "****** Warning: z_tolerance parameter is obsolete, use PINCH in deck input instead\n";
+    }
     double residual_tolerance = param.getDefault("residual_tolerance", 1e-8);
     double linsolver_verbosity = param.getDefault("linsolver_verbosity", 0);
     double linsolver_type = param.getDefault("linsolver_type", 1);
@@ -173,7 +175,7 @@ try
 		try {
 		    Opm::DeckConstPtr subdeck = ch.subDeck();
 		    Opm::SinglePhaseUpscaler upscaler;
-		    upscaler.init(subdeck, Opm::SinglePhaseUpscaler::Fixed, minpermSI, z_tolerance,
+		    upscaler.init(subdeck, Opm::SinglePhaseUpscaler::Fixed, minpermSI,
 				  residual_tolerance, linsolver_verbosity, linsolver_type, false);
             
 		    Opm::SinglePhaseUpscaler::permtensor_t upscaled_K = upscaler.upscaleSinglePhase();

--- a/examples/exp_variogram.cpp
+++ b/examples/exp_variogram.cpp
@@ -87,7 +87,9 @@ try
 
     double minperm = param.getDefault("minperm", 1e-9);
     double minpermSI = Opm::unit::convert::from(minperm, Opm::prefix::milli*Opm::unit::darcy);
-    double z_tolerance = param.getDefault("z_tolerance", 0.0);
+    if (param.has("z_tolerance")) {
+        std::cerr << "****** Warning: z_tolerance parameter is obsolete, use PINCH in deck input instead\n";
+    }
     double residual_tolerance = param.getDefault("residual_tolerance", 1e-8);
     int linsolver_verbosity = param.getDefault("linsolver_verbosity", 0);
     int linsolver_type = param.getDefault("linsolver_type", 1);
@@ -175,7 +177,7 @@ try
 
         Opm::DeckConstPtr subdeck_1 = ch.subDeck();
         Opm::SinglePhaseUpscaler upscaler_1;
-        upscaler_1.init(subdeck_1, Opm::SinglePhaseUpscaler::Fixed, minpermSI, z_tolerance,
+        upscaler_1.init(subdeck_1, Opm::SinglePhaseUpscaler::Fixed, minpermSI,
 			residual_tolerance, linsolver_verbosity, linsolver_type, false);
         Opm::SinglePhaseUpscaler::permtensor_t upscaled_K_1 = upscaler_1.upscaleSinglePhase();
         upscaled_K_1 *= (1.0/(Opm::prefix::milli*Opm::unit::darcy));
@@ -198,7 +200,7 @@ try
 	
         Opm::DeckConstPtr subdeck_2 = ch.subDeck();
         Opm::SinglePhaseUpscaler upscaler_2;
-        upscaler_2.init(subdeck_2, Opm::SinglePhaseUpscaler::Fixed, minpermSI, z_tolerance,
+        upscaler_2.init(subdeck_2, Opm::SinglePhaseUpscaler::Fixed, minpermSI,
 			residual_tolerance, linsolver_verbosity, linsolver_type, false);
         Opm::SinglePhaseUpscaler::permtensor_t upscaled_K_2 = upscaler_2.upscaleSinglePhase();
         upscaled_K_2 *= (1.0/(Opm::prefix::milli*Opm::unit::darcy));

--- a/examples/upscale_avg.cpp
+++ b/examples/upscale_avg.cpp
@@ -178,7 +178,7 @@ int main(int varnum, char** vararg) try {
    SinglePhaseUpscaler upscaler;
    upscaler.init(deck, SinglePhaseUpscaler::Fixed,
                  Opm::unit::convert::from(1e-9, Opm::prefix::milli*Opm::unit::darcy),
-                 0.0, 1e-8, 0, 1, false);
+                 1e-8, 0, 1, false);
 
 
     bool use_actnum = false;

--- a/examples/upscale_cap.cpp
+++ b/examples/upscale_cap.cpp
@@ -406,7 +406,7 @@ try
    SinglePhaseUpscaler upscaler;
    upscaler.init(deck, SinglePhaseUpscaler::Fixed,
                  Opm::unit::convert::from(minPerm, Opm::prefix::milli*Opm::unit::darcy),
-                 0.0, 1e-8, 0, 1, false);  // options on this line are noops for upscale_cap
+                 1e-8, 0, 1, false);  // options on this line are noops for upscale_cap
 
    vector<double> cellVolumes, cellPoreVolumes; 
    cellVolumes.resize(satnums.size(), 0.0);

--- a/examples/upscale_cond.cpp
+++ b/examples/upscale_cond.cpp
@@ -462,14 +462,13 @@ try
    griddims[1] = specgridRecord->getItem("NY")->getInt(0);
    griddims[2] = specgridRecord->getItem("NZ")->getInt(0);
    SinglePhaseUpscaler upscaler;
-   double ztol = 0.0;
    double linsolver_tolerance = atof(options["linsolver_tolerance"].c_str());
    int linsolver_verbosity    = atoi(options["linsolver_verbosity"].c_str());
    int linsolver_type         = atoi(options["linsolver_type"].c_str());
    bool twodim_hack = false;
    upscaler.init(deck, boundaryCondition,
                  Opm::unit::convert::from(minPerm, Opm::prefix::milli*Opm::unit::darcy),
-                 ztol, linsolver_tolerance, linsolver_verbosity, linsolver_type, twodim_hack);
+                 linsolver_tolerance, linsolver_verbosity, linsolver_type, twodim_hack);
 
    finish = clock();   timeused_tesselation = (double(finish)-double(start))/CLOCKS_PER_SEC;
    if (isMaster) cout << " (" << timeused_tesselation <<" secs)" << endl;    

--- a/examples/upscale_perm.cpp
+++ b/examples/upscale_perm.cpp
@@ -218,7 +218,6 @@ int upscale(int varnum, char** vararg) {
      */
 
 
-    double ztol = 0.0; 
     double linsolver_tolerance = atof(options["linsolver_tolerance"].c_str());
     int linsolver_verbosity = atoi(options["linsolver_verbosity"].c_str());
     int linsolver_type = atoi(options["linsolver_type"].c_str());
@@ -238,7 +237,7 @@ int upscale(int varnum, char** vararg) {
         start = clock();
         upscaler_nonperiodic.init(deck, 
                                   isFixed ? SinglePhaseUpscaler::Fixed : SinglePhaseUpscaler::Linear,
-                                  minPerm, ztol,  linsolver_tolerance, linsolver_verbosity, linsolver_type, 
+                                  minPerm,  linsolver_tolerance, linsolver_verbosity, linsolver_type, 
                                   twodim_hack, linsolver_maxit, linsolver_prolongate_factor, smooth_steps);
         finish = clock();
         timeused_nonperiodic_tesselation = (double(finish)-double(start))/CLOCKS_PER_SEC;
@@ -248,7 +247,7 @@ int upscale(int varnum, char** vararg) {
         cout << "Tesselating periodic grid ...  ";
         start = clock();
         upscaler_periodic.init(deck, SinglePhaseUpscaler::Periodic, minPerm,
-                               ztol,  linsolver_tolerance, linsolver_verbosity, linsolver_type, twodim_hack,
+                               linsolver_tolerance, linsolver_verbosity, linsolver_type, twodim_hack,
                                linsolver_maxit, linsolver_prolongate_factor, smooth_steps);
         finish = clock();
         timeused_periodic_tesselation = (double(finish)-double(start))/CLOCKS_PER_SEC;

--- a/examples/upscale_relperm.cpp
+++ b/examples/upscale_relperm.cpp
@@ -939,7 +939,6 @@ try
    if (isMaster) cout << "Tesselating grid... ";
    flush(cout);   start = clock();
    SinglePhaseUpscaler upscaler;
-   double ztol = 0.0;
    double linsolver_tolerance = atof(options["linsolver_tolerance"].c_str());
    int linsolver_verbosity = atoi(options["linsolver_verbosity"].c_str());
    int linsolver_type = atoi(options["linsolver_type"].c_str());
@@ -949,7 +948,7 @@ try
    bool twodim_hack = false;
    upscaler.init(deck, boundaryCondition,
                  Opm::unit::convert::from(minPerm, Opm::prefix::milli*Opm::unit::darcy),
-                 ztol, linsolver_tolerance,
+                 linsolver_tolerance,
                  linsolver_verbosity, linsolver_type, twodim_hack,
                  linsolver_maxit, linsolver_prolongate_factor, smooth_steps);
 

--- a/examples/upscale_relpermvisc.cpp
+++ b/examples/upscale_relpermvisc.cpp
@@ -824,14 +824,13 @@ try
     if (isMaster) cout << "Tesselating grid... ";
     flush(cout);   start = clock();
     SinglePhaseUpscaler upscaler;
-    double ztol = 0.0;
     double linsolver_tolerance = atof(options["linsolver_tolerance"].c_str());
     int linsolver_verbosity = atoi(options["linsolver_verbosity"].c_str());
     int linsolver_type = atoi(options["linsolver_type"].c_str());
     bool twodim_hack = false;
     upscaler.init(deck, boundaryCondition,
                   Opm::unit::convert::from(minPerm, Opm::prefix::milli*Opm::unit::darcy),
-                  ztol, linsolver_tolerance, linsolver_verbosity, linsolver_type, twodim_hack);
+                  linsolver_tolerance, linsolver_verbosity, linsolver_type, twodim_hack);
  
     finish = clock();   timeused_tesselation = (double(finish)-double(start))/CLOCKS_PER_SEC;
     if (isMaster) cout << " (" << timeused_tesselation <<" secs)" << endl;

--- a/examples/upscale_steadystate_implicit.cpp
+++ b/examples/upscale_steadystate_implicit.cpp
@@ -288,7 +288,7 @@ try
     }
     Opm::SinglePhaseUpscaler spupscaler; // needed to access porosities and cell volumes
     spupscaler.init(deck, Opm::SinglePhaseUpscaler::Fixed,
-                    0.0,0.0, linsolver_tolerance, linsolver_verbosity, linsolver_type, false, linsolver_maxit,
+                    0.0, linsolver_tolerance, linsolver_verbosity, linsolver_type, false, linsolver_maxit,
                     linsolver_prolongate_factor, linsolver_smooth_steps);
     std::vector<double>  cellPoreVolumes; 
     cellPoreVolumes.resize(satnums.size(), 0.0);

--- a/opm/upscaling/UpscalerBase.hpp
+++ b/opm/upscaling/UpscalerBase.hpp
@@ -78,7 +78,6 @@ namespace Opm
 	void init(Opm::DeckConstPtr deck,
                   BoundaryConditionType bctype,
                   double perm_threshold,
-                  double z_tolerance = 0.0,
                   double residual_tolerance = 1e-8,
                   int linsolver_verbosity = 0,
                   int linsolver_type = 3,

--- a/opm/upscaling/UpscalerBase_impl.hpp
+++ b/opm/upscaling/UpscalerBase_impl.hpp
@@ -131,7 +131,6 @@ namespace Opm
     inline void UpscalerBase<Traits>::init(Opm::DeckConstPtr deck,
                                            BoundaryConditionType bctype,
                                            double perm_threshold,
-                                           double z_tolerance,
                                            double residual_tolerance,
                                            int linsolver_verbosity,
                                            int linsolver_type,
@@ -155,7 +154,7 @@ namespace Opm
         bool clip_z = (bctype_ == Periodic);
         bool unique_bids = (bctype_ == Linear || bctype_ == Periodic);
         std::string rock_list("no_list");
-	setupGridAndPropsEclipse(deck, z_tolerance,
+	setupGridAndPropsEclipse(deck,
                                  periodic_ext, turn_normals, clip_z, unique_bids,
                                  perm_threshold, rock_list,
                                  useJ<ResProp>(), 1.0, 0.0,


### PR DESCRIPTION
This means that PINCH must be used in the input deck, whereas before, z_tolerance was available as a program parameter (but only for some programs). A benefit is that all programs will now uniformly accept PINCH in the input decks.

If you use the z_tolerance parameter in a program that used to accept it, you will get a warning.

Requires OPM/dune-cornerpoint#104 and OPM/opm-porsol#111.
