### PR TITLE
add "sections" item to custom "RHO" keyword

### DIFF
--- a/opm/upscaling/ParserAdditions.hpp
+++ b/opm/upscaling/ParserAdditions.hpp
@@ -36,7 +36,7 @@ namespace Opm {
 inline void addNonStandardUpscalingKeywords(Opm::ParserPtr parser)
 {
     const char *rhoJsonData =
-        "{\"name\" : \"RHO\", \"data\" : {\"value_type\" : \"DOUBLE\" }}\n";
+        "{\"name\" : \"RHO\", \"sections\" : [], \"data\" : {\"value_type\" : \"DOUBLE\" }}\n";
 
     Json::JsonObject rhoJson(rhoJsonData);
     Opm::ParserKeywordConstPtr rhoKeyword = Opm::ParserKeyword::createFromJson(rhoJson);


### PR DESCRIPTION
this is required after OPM/opm-parser#296 has been merged, but it can
be merged before...
