### PR TITLE
update debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,8 @@ Build-Depends: build-essential, debhelper (>= 9), libboost-filesystem-dev,
                libdune-common-dev, libdune-istl-dev, cmake, libtinyxml-dev, bc,
                libert.ecl-dev, git, zlib1g-dev, libtool, libopm-material-dev,
                libdune-cornerpoint-dev, libdune-grid-dev, libopm-porsol-dev,
-               doxygen, texlive-latex-extra, texlive-latex-recommended, ghostscript
+               doxygen, texlive-latex-extra, texlive-latex-recommended, ghostscript,
+               libopm-parser-dev, libboost-iostreams-dev, pkg-config
 Standards-Version: 3.9.2
 Section: libs
 Homepage: http://opm-project.org
@@ -34,15 +35,18 @@ Suggests: libopm-upscaling-doc
 Description: OPM upscaling library -- applications
  This module implements single-phase and steady-state upscaling methods.
 
-Package: libopm-upscaling1
-Section: libs
-Pre-Depends: ${misc:Pre-Depends}, multiarch-support
-Architecture: any
-Multi-Arch: same
-Depends: ${shlibs:Depends}, ${misc:Depends}
-Provides: libopm-upscaling
-Description: OPM upscaling library
- This module implements single-phase and steady-state upscaling methods.
+# Disabled until dune is bumped to 2.3.
+# No library built with 2.2.1 as elasticity code is excluded
+
+#Package: libopm-upscaling1
+#Section: libs
+#Pre-Depends: ${misc:Pre-Depends}, multiarch-support
+#Architecture: any
+#Multi-Arch: same
+#Depends: ${shlibs:Depends}, ${misc:Depends}
+#Provides: libopm-upscaling
+#Description: OPM upscaling library
+# This module implements single-phase and steady-state upscaling methods.
 
 Package: libopm-upscaling1-doc
 Section: doc

--- a/debian/libopm-upscaling1-dbg.install
+++ b/debian/libopm-upscaling1-dbg.install
@@ -1,1 +1,0 @@
-usr/lib/debug/usr/lib/*/*.debug

--- a/debian/libopm-upscaling1-dev.install
+++ b/debian/libopm-upscaling1-dev.install
@@ -1,5 +1,3 @@
 usr/include/*
-usr/lib/*/lib*.so
 usr/lib/dunecontrol/*
-usr/lib/*/pkgconfig/*
 usr/share/cmake/*

--- a/debian/libopm-upscaling1.install
+++ b/debian/libopm-upscaling1.install
@@ -1,1 +1,0 @@
-usr/lib/*/lib*.so.*

--- a/debian/rules
+++ b/debian/rules
@@ -27,3 +27,6 @@ override_dh_auto_install:
 
 override_dh_installdocs:
 	dh_installdocs --link-doc=libopm-upscaling1
+
+override_dh_strip:
+	dh_strip -plibopm-upscaling1-bin --dbg-package=libopm-upscaling1-dbg


### PR DESCRIPTION
- update to reflect new dependencies
- disable the library package. no library is built since the elasticity code is disabled with dune < 2.3 and repos only provide 2.2.1
