### PR TITLE
Adapt to RESULT_PATH losing trailing slash

### DIFF
--- a/TestUpscalingBinaries.cmake
+++ b/TestUpscalingBinaries.cmake
@@ -52,7 +52,7 @@ macro (add_test_upscale_perm gridname bcs rows)
                            upscale_perm_BC${bcs}_${gridname}
                            ${tol} ${rows} 3
                TEST_ARGS -bc ${bcs}
-                         -output ${RESULT_PATH}upscale_perm_BC${bcs}_${gridname}.txt
+                         -output ${RESULT_PATH}/upscale_perm_BC${bcs}_${gridname}.txt
                          ${INPUT_DATA_PATH}/grids/${gridname}.grdecl)
 endmacro (add_test_upscale_perm gridname bcs)
 


### PR DESCRIPTION
This change catches up to removal of trailing slash character in the `RESULT_PATH` variable in commit 16e06b1 (PR #147).