### PR TITLE
Added cfloat include, build failed on some systems

### DIFF
--- a/opm/upscaling/RelPermUtils.cpp
+++ b/opm/upscaling/RelPermUtils.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <exception>
 #include <sstream>
+#include <cfloat>  // FOR DBL_MAX/DBL_MIN
 
 namespace Opm {
 


### PR DESCRIPTION
Got a build error that seemed to be related to a missing include (see https://ci.opm-project.org/job/opm-upscaling-install/723/console) 