### PR TITLE
ParserAdditions passes json object, not keyword

### DIFF
--- a/opm/upscaling/ParserAdditions.hpp
+++ b/opm/upscaling/ParserAdditions.hpp
@@ -39,7 +39,7 @@ inline void addNonStandardUpscalingKeywords(Opm::ParserPtr parser)
         "{\"name\" : \"RHO\", \"sections\" : [], \"data\" : {\"value_type\" : \"DOUBLE\" }}\n";
 
     Json::JsonObject rhoJson(rhoJsonData);
-    parser->addParserKeyword( std::make_shared<const ParserKeyword>( rhoJson ));
+    parser->addParserKeyword( rhoJson );
 }
 
 }


### PR DESCRIPTION
This feels more natural and is also compatible with
https://github.com/OPM/opm-parser/pull/691