### PR TITLE
Silence warnings

### DIFF
--- a/examples/SimulatorTester.hpp
+++ b/examples/SimulatorTester.hpp
@@ -95,8 +95,8 @@ namespace Opm
                 // Comparing old to new.
                 int num_cells = saturation.size();
                 double maxdiff = 0.0;
-                for (int i = 0; i < num_cells; ++i) {
-                    maxdiff = std::max(maxdiff, std::fabs(saturation[i] - saturation_old[i]));
+                for (int cell = 0; cell < num_cells; ++cell) {
+                    maxdiff = std::max(maxdiff, std::fabs(saturation[cell] - saturation_old[cell]));
                 }
                 std::cout << "Maximum saturation change: " << maxdiff << std::endl;
 

--- a/examples/known_answer_test.cpp
+++ b/examples/known_answer_test.cpp
@@ -37,13 +37,19 @@
 
 #include "config.h"
 
+#include <opm/core/utility/Units.hpp>
+
 #include <algorithm>
 #include <iostream>
 #include <iomanip>
-
-
 #include <array>
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
+#include <dune/grid/io/file/vtk/vtkwriter.hh>
+#include <dune/grid/yaspgrid.hh>
 #include <dune/common/version.hh>
+
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2,3)
 #include <dune/common/parallel/mpihelper.hh>
 #else
@@ -55,7 +61,8 @@
 #include <dune/common/array.hh>
 #endif
 
-#include <opm/core/utility/Units.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
 
 // #if HAVE_ALUGRID
 // #include <dune/common/shared_ptr.hh>
@@ -66,18 +73,13 @@
 // #endif
 
 #include <opm/porsol/common/SimulatorUtilities.hpp>
-#include <dune/grid/io/file/vtk/vtkwriter.hh>
-
-#include <dune/grid/yaspgrid.hh>
 #include <dune/grid/CpGrid.hpp>
-
 #include <opm/porsol/common/fortran.hpp>
 #include <opm/porsol/common/blas_lapack.hpp>
 #include <opm/porsol/common/Matrix.hpp>
 #include <opm/porsol/common/GridInterfaceEuler.hpp>
 #include <opm/porsol/common/ReservoirPropertyCapillary.hpp>
 #include <opm/porsol/common/BoundaryConditions.hpp>
-
 #include <opm/porsol/mimetic/MimeticIPEvaluator.hpp>
 #include <opm/porsol/mimetic/IncompFlowSolverHybrid.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>

--- a/examples/mimetic_aniso_solver_test.cpp
+++ b/examples/mimetic_aniso_solver_test.cpp
@@ -35,12 +35,32 @@
 
 #include "config.h"
 
+#include <opm/core/utility/Units.hpp>
+
+#include <dune/grid/CpGrid.hpp>
+#include <opm/output/eclipse/EclipseGridInspector.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/porsol/common/fortran.hpp>
+#include <opm/porsol/common/blas_lapack.hpp>
+#include <opm/porsol/common/Matrix.hpp>
+#include <opm/porsol/common/GridInterfaceEuler.hpp>
+#include <opm/porsol/common/ReservoirPropertyCapillaryAnisotropicRelperm.hpp>
+#include <opm/porsol/common/BoundaryConditions.hpp>
+#include <opm/porsol/mimetic/MimeticIPAnisoRelpermEvaluator.hpp>
+#include <opm/porsol/mimetic/IncompFlowSolverHybrid.hpp>
+#include <opm/core/utility/parameters/ParameterGroup.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+
 #include <algorithm>
 #include <iostream>
 #include <iomanip>
-
-
 #include <array>
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
+#include <dune/grid/yaspgrid.hh>
 
 #include <dune/common/version.hh>
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
@@ -49,28 +69,7 @@
 #include <dune/common/mpihelper.hh>
 #endif
 
-#include <opm/core/utility/Units.hpp>
-
-#include <dune/grid/yaspgrid.hh>
-#include <dune/grid/CpGrid.hpp>
-#include <opm/output/eclipse/EclipseGridInspector.hpp>
-
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-
-#include <opm/porsol/common/fortran.hpp>
-#include <opm/porsol/common/blas_lapack.hpp>
-#include <opm/porsol/common/Matrix.hpp>
-#include <opm/porsol/common/GridInterfaceEuler.hpp>
-#include <opm/porsol/common/ReservoirPropertyCapillaryAnisotropicRelperm.hpp>
-#include <opm/porsol/common/BoundaryConditions.hpp>
-
-#include <opm/porsol/mimetic/MimeticIPAnisoRelpermEvaluator.hpp>
-#include <opm/porsol/mimetic/IncompFlowSolverHybrid.hpp>
-#include <opm/core/utility/parameters/ParameterGroup.hpp>
-
-#include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
-#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 
 template <int dim, class Interface>

--- a/examples/mimetic_solver_test.cpp
+++ b/examples/mimetic_solver_test.cpp
@@ -35,12 +35,30 @@
 
 #include "config.h"
 
+#include <opm/porsol/common/SimulatorUtilities.hpp>
+#include <dune/grid/io/file/vtk/vtkwriter.hh>
+
+#include <dune/grid/CpGrid.hpp>
+#include <opm/porsol/common/fortran.hpp>
+#include <opm/porsol/common/blas_lapack.hpp>
+#include <opm/porsol/common/Matrix.hpp>
+#include <opm/porsol/common/GridInterfaceEuler.hpp>
+#include <opm/porsol/common/ReservoirPropertyCapillary.hpp>
+#include <opm/porsol/common/BoundaryConditions.hpp>
+#include <opm/porsol/common/setupGridAndProps.hpp>
+#include <opm/porsol/mimetic/MimeticIPEvaluator.hpp>
+#include <opm/porsol/mimetic/IncompFlowSolverHybrid.hpp>
+#include <opm/core/utility/parameters/ParameterGroup.hpp>
+#include <opm/core/utility/Units.hpp>
+
 #include <algorithm>
 #include <iostream>
 #include <iomanip>
-
-
 #include <array>
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
+#include <dune/grid/yaspgrid.hh>
 
 #include <dune/common/version.hh>
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
@@ -48,7 +66,6 @@
 #else
 #include <dune/common/mpihelper.hh>
 #endif
-#include <opm/core/utility/Units.hpp>
 
 #if HAVE_ALUGRID
 #include <dune/common/shared_ptr.hh>
@@ -58,23 +75,7 @@
 #include <dune/grid/alugrid.hh>
 #endif
 
-#include <opm/porsol/common/SimulatorUtilities.hpp>
-#include <dune/grid/io/file/vtk/vtkwriter.hh>
-
-#include <dune/grid/yaspgrid.hh>
-#include <dune/grid/CpGrid.hpp>
-
-#include <opm/porsol/common/fortran.hpp>
-#include <opm/porsol/common/blas_lapack.hpp>
-#include <opm/porsol/common/Matrix.hpp>
-#include <opm/porsol/common/GridInterfaceEuler.hpp>
-#include <opm/porsol/common/ReservoirPropertyCapillary.hpp>
-#include <opm/porsol/common/BoundaryConditions.hpp>
-#include <opm/porsol/common/setupGridAndProps.hpp>
-
-#include <opm/porsol/mimetic/MimeticIPEvaluator.hpp>
-#include <opm/porsol/mimetic/IncompFlowSolverHybrid.hpp>
-#include <opm/core/utility/parameters/ParameterGroup.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 
 

--- a/examples/sim_blackoil_impes.cpp
+++ b/examples/sim_blackoil_impes.cpp
@@ -23,8 +23,16 @@
 
 #include <opm/porsol/blackoil/fluid/BlackoilPVT.hpp>
 #include <opm/porsol/blackoil/BlackoilFluid.hpp>
-
 #include <opm/porsol/blackoil/BlackoilSimulator.hpp>
+#include <opm/porsol/common/SimulatorUtilities.hpp>
+#include <dune/grid/CpGrid.hpp>
+#include <opm/porsol/common/Rock.hpp>
+#include <opm/porsol/mimetic/TpfaCompressible.hpp>
+#include <opm/core/utility/StopWatch.hpp>
+#include <opm/porsol/blackoil/BlackoilWells.hpp>
+#include <opm/porsol/blackoil/ComponentTransport.hpp>
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
@@ -33,13 +41,7 @@
 #include <dune/common/mpihelper.hh>
 #endif
 
-#include <opm/porsol/common/SimulatorUtilities.hpp>
-#include <dune/grid/CpGrid.hpp>
-#include <opm/porsol/common/Rock.hpp>
-#include <opm/porsol/mimetic/TpfaCompressible.hpp>
-#include <opm/core/utility/StopWatch.hpp>
-#include <opm/porsol/blackoil/BlackoilWells.hpp>
-#include <opm/porsol/blackoil/ComponentTransport.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <iostream>
 

--- a/examples/sim_co2_impes.cpp
+++ b/examples/sim_co2_impes.cpp
@@ -21,6 +21,7 @@
 
 #include "config.h"
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
@@ -28,6 +29,8 @@
 #else
 #include <dune/common/mpihelper.hh>
 #endif
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/porsol/common/SimulatorUtilities.hpp>
 #include <opm/porsol/common/Rock.hpp>

--- a/examples/upscale_cond.cpp
+++ b/examples/upscale_cond.cpp
@@ -61,12 +61,16 @@
 #include <map>
 #include <sys/utsname.h>
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
 #include <dune/common/version.hh>
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
 #else
 #include <dune/common/mpihelper.hh>
 #endif
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>

--- a/examples/upscale_cond.cpp
+++ b/examples/upscale_cond.cpp
@@ -543,8 +543,7 @@ try
    double Swirvolume = 0;
    double Sworvolume = 0;
    const std::vector<int>& ecl_idx = upscaler.grid().globalCell();
-   Dune::CpGrid::Codim<0>::LeafIterator c = upscaler.grid().leafbegin<0>();
-   for (; c != upscaler.grid().leafend<0>(); ++c) {
+   for (auto c = upscaler.grid().leafbegin<0>(); c != upscaler.grid().leafend<0>(); ++c) {
        size_t cell_idx = ecl_idx[c->index()];
        if (satnums[cell_idx] > 0) { // Satnum zero is "no rock"
            cellVolumes[cell_idx] = c->geometry().volume();
@@ -737,8 +736,7 @@ try
        }
        
        double waterVolume = 0.0;
-       Dune::CpGrid::Codim<0>::LeafIterator c = upscaler.grid().leafbegin<0>();
-       for (; c != upscaler.grid().leafend<0>(); ++c) {
+       for (auto c = upscaler.grid().leafbegin<0>(); c != upscaler.grid().leafend<0>(); ++c) {
            size_t cell_idx = ecl_idx[c->index()];
            //           for (size_t cell_idx = 0; cell_idx < satnums.size(); ++cell_idx) {
            //if (LFgrid.getCellIndex(cell_idx) != EMPTY) {
@@ -866,8 +864,7 @@ try
            // capillary pressure:
            waterVolumeLF = 0.0;
 
-           Dune::CpGrid::Codim<0>::LeafIterator c = upscaler.grid().leafbegin<0>();
-           for (; c != upscaler.grid().leafend<0>(); ++c) {
+           for (auto c = upscaler.grid().leafbegin<0>(); c != upscaler.grid().leafend<0>(); ++c) {
                size_t cell_idx = ecl_idx[c->index()];
                //               for (size_t cell_idx = 0; cell_idx < satnums.size(); ++cell_idx) {
                //  if (LFgrid.getCellIndex(cell_idx) != EMPTY) {

--- a/examples/upscale_elasticity.cpp
+++ b/examples/upscale_elasticity.cpp
@@ -13,13 +13,11 @@
 # include "config.h"     
 #endif
 
-#include <iostream>
-#include <unistd.h>
-#include <cstring>
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
 #include <dune/common/exceptions.hh> // We use exceptions
 #include <dune/common/version.hh>
-#include <opm/core/utility/StopWatch.hpp>
-#include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <dune/grid/io/file/vtk/vtkwriter.hh>
 #include <dune/istl/matrixmarket.hh>
 #include <dune/common/fmatrix.hh>
@@ -35,8 +33,16 @@
 #include <dune/common/mpihelper.hh>
 #endif
 
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
 #include <opm/elasticity/elasticity_upscale.hpp>
 #include <opm/elasticity/matrixops.hpp>
+#include <opm/core/utility/StopWatch.hpp>
+#include <opm/core/utility/parameters/ParameterGroup.hpp>
+
+#include <iostream>
+#include <unistd.h>
+#include <cstring>
 
 using namespace Opm::Elasticity;
 

--- a/examples/upscale_relperm.cpp
+++ b/examples/upscale_relperm.cpp
@@ -69,12 +69,16 @@
 #include <map>
 #include <sys/utsname.h>
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
 #include <dune/common/version.hh>
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
 #else
 #include <dune/common/mpihelper.hh>
 #endif
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>

--- a/examples/upscale_steadystate_implicit.cpp
+++ b/examples/upscale_steadystate_implicit.cpp
@@ -367,11 +367,11 @@ try
         } {
             init_sat.resize(num_cells, saturations[satidx]);
         }
-        const Opm::SparseTable<double>::row_type pdrops = all_pdrops[satidx];
-        int num_pdrops = pdrops.size();
-        for (int pidx = 0; pidx < num_pdrops; ++pidx) {
+        const Opm::SparseTable<double>::row_type pressdrops = all_pdrops[satidx];
+        int num_pressdrops = pressdrops.size();
+        for (int pidx = 0; pidx < num_pressdrops; ++pidx) {
             upscaler.initSatLimits(init_sat);
-            double pdrop = pdrops[pidx];
+            double pdrop = pressdrops[pidx];
             bool success = false;
             std::pair<permtensor_t, permtensor_t> lambda
                 = upscaler.upscaleSteadyState(fldir, init_sat, saturations[satidx], pdrop, upscaled_K, success);

--- a/opm/elasticity/applier.hpp
+++ b/opm/elasticity/applier.hpp
@@ -62,7 +62,7 @@ void PreApplier::apply(Vector& v, Vector& d)
 }
 
   template<>
-void InverseApplier::pre(Vector& x, Vector& b)
+void InverseApplier::pre(Vector& /* x */, Vector& /* b */)
 {
 }
 
@@ -73,7 +73,7 @@ void PreApplier::pre(Vector& x, Vector& b)
 }
 
   template<>
-void InverseApplier::post(Vector& x)
+void InverseApplier::post(Vector& /* x */)
 {
 }
 

--- a/opm/elasticity/asmhandler.hpp
+++ b/opm/elasticity/asmhandler.hpp
@@ -12,10 +12,16 @@
 #ifndef ASMHANDLER_HPP_
 #define ASMHANDLER_HPP_
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
 #include <dune/geometry/referenceelements.hh>
 #include <dune/common/fmatrix.hh>
 #include <dune/istl/bvector.hh>
 #include <dune/common/fvector.hh>
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+
 #include <opm/elasticity/logutils.hpp>
 #include <opm/elasticity/mpc.hh>
 #include <opm/elasticity/matrixops.hpp>

--- a/opm/elasticity/asmhandler_impl.hpp
+++ b/opm/elasticity/asmhandler_impl.hpp
@@ -54,7 +54,7 @@ void ASMHandler<GridType>::addDOF(int row, int erow,
                               const Dune::FieldVector<double,esize>* S,
                               const LeafIndexSet& set,
                               const LeafIterator& cell, 
-                              Vector* b,
+                              Vector* bptr,
                               double scale)
 {
   if (row == -1)
@@ -76,8 +76,8 @@ void ASMHandler<GridType>::addDOF(int row, int erow,
       }
     }
   }
-  if (S && b)
-    (*b)[row] += scale*(*S)[erow];
+  if (S && bptr)
+    (*bptr)[row] += scale*(*S)[erow];
 }
 
   template<class GridType>

--- a/opm/elasticity/boundarygrid.hh
+++ b/opm/elasticity/boundarygrid.hh
@@ -12,12 +12,17 @@
 #ifndef BOUNDARYGRID_HH_
 #define BOUNDARYGRID_HH_
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
 #include <dune/common/version.hh>
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
 #include <dune/geometry/referenceelements.hh>
 #include <dune/geometry/genericgeometry/matrixhelper.hh>
 #include <dune/grid/common/mcmgmapper.hh>
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
 
 #include <vector>
 

--- a/opm/elasticity/elasticity_preconditioners.cpp
+++ b/opm/elasticity/elasticity_preconditioners.cpp
@@ -17,11 +17,11 @@
 namespace Opm {
 namespace Elasticity {
 
-std::shared_ptr<FastAMG::type> FastAMG::setup(int pre, int post, int target,
+std::shared_ptr<FastAMG::type> FastAMG::setup(int /* pre */, int /* post */, int target,
                                               int zcells,
                                               std::shared_ptr<Operator>& op,
-                                              const Dune::CpGrid& gv,
-                                              ASMHandler<Dune::CpGrid>& A,
+                                              const Dune::CpGrid& /* gv */,
+                                              ASMHandler<Dune::CpGrid>& /* A */,
                                               bool& copy)
 {
   AMG1<JACSmoother>::Criterion crit;

--- a/opm/elasticity/elasticity_preconditioners.hpp
+++ b/opm/elasticity/elasticity_preconditioners.hpp
@@ -12,23 +12,27 @@
 #ifndef ELASTICITY_PRECONDITIONERS_HPP_
 #define ELASTICITY_PRECONDITIONERS_HPP_
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
 #include <dune/common/fmatrix.hh>
 #include <dune/istl/bcrsmatrix.hh>
 #include <dune/istl/matrixmatrix.hh>
 #include <dune/istl/ilu.hh>
 #include <dune/istl/solvers.hh>
 #include <dune/istl/preconditioners.hh>
-#include <dune/grid/CpGrid.hpp>
-
-#include <opm/elasticity/asmhandler.hpp>
-#include <opm/elasticity/matrixops.hpp>
-
 #include <dune/istl/superlu.hh>
 #include <dune/istl/umfpack.hh>
 #include <dune/istl/paamg/amg.hh>
 #include <dune/istl/paamg/fastamg.hh>
 #include <dune/istl/paamg/twolevelmethod.hh>
 #include <dune/istl/overlappingschwarz.hh>
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <dune/grid/CpGrid.hpp>
+#include <opm/elasticity/asmhandler.hpp>
+#include <opm/elasticity/matrixops.hpp>
+
 
 namespace Opm {
 namespace Elasticity {

--- a/opm/elasticity/elasticity_preconditioners.hpp
+++ b/opm/elasticity/elasticity_preconditioners.hpp
@@ -75,7 +75,7 @@ struct Schwarz {
   //! \param[in] gv The cornerpoint grid
   //! \param[out] thread Whether or not to clone for threads
   static std::shared_ptr<type>
-                setup(int pre, int post, int target, int zcells,
+                setup(int /* pre */, int /* post */, int /* target */, int /* zcells */,
                       std::shared_ptr<Operator>& op, const Dune::CpGrid& gv,
                       ASMHandler<Dune::CpGrid>& A, bool& copy)
   {
@@ -115,8 +115,8 @@ struct AMG1 {
   //! \param[out] thread Whether or not to clone for threads
   static std::shared_ptr<type>
                 setup(int pre, int post, int target, int zcells,
-                      std::shared_ptr<Operator>& op, const Dune::CpGrid& gv,
-                      ASMHandler<Dune::CpGrid>& A, bool& copy)
+                      std::shared_ptr<Operator>& op, const Dune::CpGrid& /* gv */,
+                      ASMHandler<Dune::CpGrid>& /* A */, bool& copy)
   {
     Criterion crit;
     typename AMG1<Smoother>::type::SmootherArgs args;

--- a/opm/elasticity/elasticity_upscale.hpp
+++ b/opm/elasticity/elasticity_upscale.hpp
@@ -12,6 +12,9 @@
 #ifndef ELASTICITY_UPSCALE_HPP_
 #define ELASTICITY_UPSCALE_HPP_
 
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
 #include <dune/common/fmatrix.hh>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <dune/grid/common/mcmgmapper.hh>
@@ -21,6 +24,8 @@
 #include <dune/istl/preconditioners.hh>
 #include <dune/grid/CpGrid.hpp>
 #include <opm/elasticity/shapefunctions.hpp>
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/elasticity/asmhandler.hpp>
 #include <opm/elasticity/boundarygrid.hh>

--- a/opm/elasticity/elasticity_upscale.hpp
+++ b/opm/elasticity/elasticity_upscale.hpp
@@ -258,7 +258,7 @@ class ElasticityUpscale
     //! \param[in] dir The direction of the MPC
     //! \param[in] slave The slave node index
     //! \param[in] m The vertices on the master grid
-    void addMPC(Direction dir, int slave, 
+    void addMPC(Direction dir, int slavenode,
                 const BoundaryGrid::Vertex& m);
 
     //! \brief Establish periodic boundaries using the MPC approach
@@ -370,9 +370,9 @@ class ElasticityUpscale
     //! \param[in] dir The coordinate direction to enforce periodicity in
     //! \param[in] slave The slave point grid
     //! \param[in] master The master quad grid
-    void periodicPlane(Direction plane, Direction dir,
-                       const std::vector<BoundaryGrid::Vertex>& slave,
-                       const BoundaryGrid& master);
+    void periodicPlane(Direction planenormal, Direction dir,
+                       const std::vector<BoundaryGrid::Vertex>& slavepointgrid,
+                       const BoundaryGrid& mastergrid);
 
     //! \brief Fix the DOFs in a given point on the grid
     //! \param[in] dir The coordinate direction to fix in

--- a/opm/elasticity/elasticity_upscale_impl.hpp
+++ b/opm/elasticity/elasticity_upscale_impl.hpp
@@ -157,10 +157,10 @@ IMPL_FUNC(void, findBoundaries(double* min, double* max))
   }
 }
 
-IMPL_FUNC(void, addMPC(Direction dir, int slave,
+IMPL_FUNC(void, addMPC(Direction dir, int slavenode,
                        const BoundaryGrid::Vertex& m))
 {
-  MPC* mpc = new MPC(slave,log2(dir)+1);
+  MPC* mpc = new MPC(slavenode,log2(dir)+1);
   if (m.i > -1) { // we matched a node exactly
     mpc->addMaster(m.i,log2(dir)+1,1.f);
   } else {
@@ -171,17 +171,17 @@ IMPL_FUNC(void, addMPC(Direction dir, int slave,
   A.addMPC(mpc);
 }
 
-IMPL_FUNC(void, periodicPlane(Direction plane,
-                              Direction dir, 
-                              const std::vector<BoundaryGrid::Vertex>& slave,
-                              const BoundaryGrid& master))
+IMPL_FUNC(void, periodicPlane(Direction /*plane */,
+                              Direction /* dir */,
+                              const std::vector<BoundaryGrid::Vertex>& slavepointgrid,
+                              const BoundaryGrid& mastergrid))
 {
-  for (size_t i=0;i<slave.size();++i) {
+  for (size_t i=0;i<slavepointgrid.size();++i) {
     BoundaryGrid::Vertex coord;
-    if (master.find(coord,slave[i])) {
-      addMPC(X,slave[i].i,coord);
-      addMPC(Y,slave[i].i,coord);
-      addMPC(Z,slave[i].i,coord);
+    if (mastergrid.find(coord,slavepointgrid[i])) {
+      addMPC(X,slavepointgrid[i].i,coord);
+      addMPC(Y,slavepointgrid[i].i,coord);
+      addMPC(Z,slavepointgrid[i].i,coord);
     }
   }
 }
@@ -232,7 +232,7 @@ static std::vector< std::vector<int> > renumber(const BoundaryGrid& b,
 
 IMPL_FUNC(int, addBBlockMortar(const BoundaryGrid& b1,
                                const BoundaryGrid& interface,
-                               int dir, int n1, int n2,
+                               int /* dir */, int n1, int n2,
                                int colofs))
 {
   // renumber the linear grid to the real multiplier grid
@@ -522,7 +522,7 @@ IMPL_FUNC(void, assemble(int loadcase, bool matrix))
 
 IMPL_FUNC(template<int comp> void,
           averageStress(Dune::FieldVector<ctype,comp>& sigma,
-                        const Vector& u, int loadcase))
+                        const Vector& uarg, int loadcase))
 {
   if (loadcase < 0 || loadcase > 5)
     return;
@@ -544,7 +544,7 @@ IMPL_FUNC(template<int comp> void,
     Dune::GeometryType gt = it->type();
 
     Dune::FieldVector<ctype,bfunc*dim> v;
-    A.extractValues(v,u,it);
+    A.extractValues(v,uarg,it);
 
     // get a quadrature rule of order two for the given geometry type
     const Dune::QuadratureRule<ctype,dim>& rule = Dune::QuadratureRules<ctype,dim>::rule(gt,2);
@@ -698,9 +698,9 @@ IMPL_FUNC(void, loadMaterialsFromGrid(const std::string& file))
     }
     bySat = false;
   } else {
-    for (size_t j=0; j < volumeFractions.size(); ++j) {
-      volumeFractions[j] /= totalvolume;
-      std::cout << "SATNUM " << j+1 << ": " << volumeFractions[j]*100 << '%' << std::endl;
+    for (size_t jj=0; jj < volumeFractions.size(); ++jj) {
+      volumeFractions[jj] /= totalvolume;
+      std::cout << "SATNUM " << jj+1 << ": " << volumeFractions[jj]*100 << '%' << std::endl;
     }
     bySat = true;
   }
@@ -720,9 +720,9 @@ IMPL_FUNC(void, loadMaterialsFromRocklist(const std::string& file,
   int mats;
   f >> mats;
   for (int i=0;i<mats;++i) {
-    std::string file;
-    f >> file;
-    cache.push_back(std::shared_ptr<Material>(Material::create(i+1,file)));
+    std::string matfile;
+    f >> matfile;
+    cache.push_back(std::shared_ptr<Material>(Material::create(i+1,matfile)));
   }
 
   // scale E modulus of materials

--- a/opm/elasticity/elasticity_upscale_impl.hpp
+++ b/opm/elasticity/elasticity_upscale_impl.hpp
@@ -123,8 +123,8 @@ IMPL_FUNC(BoundaryGrid, extractMasterFace(Direction dir,
   int p=0;
   std::map<double, std::vector<BoundaryGrid::Quad> >::const_iterator it;
   for (it = nodeMap.begin(); it != nodeMap.end(); ++it, ++p) {
-    for (size_t i=0;i<it->second.size();++i)
-      result.addToColumn(p,it->second[i]);
+    for (size_t ii=0;ii<it->second.size();++ii)
+      result.addToColumn(p,it->second[ii]);
   }
 
   return result;
@@ -493,8 +493,8 @@ IMPL_FUNC(void, assemble(int loadcase, bool matrix))
           if (detJ <= 1.e-5 && verbose) {
             std::cout << "cell " << color[i][j][k] << " is (close to) degenerated, detJ " << detJ << std::endl;
             double zdiff=0.0;
-            for (int i=0;i<4;++i)
-              zdiff = std::max(zdiff, it->geometry().corner(i+4)[2]-it->geometry().corner(i)[2]);
+            for (int ii=0;ii<4;++ii)
+              zdiff = std::max(zdiff, it->geometry().corner(ii+4)[2]-it->geometry().corner(ii)[2]);
             std::cout << " - Consider setting ctol larger than " << zdiff << std::endl;
           }
 

--- a/opm/elasticity/material.hh
+++ b/opm/elasticity/material.hh
@@ -12,8 +12,12 @@
 #ifndef MATERIAL_HH_
 #define MATERIAL_HH_
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
 #include <dune/common/fmatrix.hh>
 #include <dune/common/dynvector.hh>
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 namespace Opm {
 namespace Elasticity {

--- a/opm/elasticity/material.hh
+++ b/opm/elasticity/material.hh
@@ -56,7 +56,7 @@ public:
   //! \brief Returns the number of parameters describing this material.
   virtual int numPar() const = 0;
   //! \brief Returns the \a ipar'th parameter describing this material.
-  virtual double getPar(int ipar = 1) const
+  virtual double getPar(int /* ipar */ = 1) const
   {
     return double(0);
   }

--- a/opm/elasticity/materials.cpp
+++ b/opm/elasticity/materials.cpp
@@ -145,8 +145,8 @@ bool OrthotropicD::getConstitutiveMatrix (Dune::FieldMatrix<double,6,6>& C,
   return true;
 }
 
-bool OrthotropicD::getConstitutiveMatrix (Dune::FieldMatrix<double,3,3>& C,
-                                          bool invers) const
+bool OrthotropicD::getConstitutiveMatrix (Dune::FieldMatrix<double,3,3>& /* C */,
+                                          bool /* invers */) const
 {
   return false;
 }
@@ -212,8 +212,8 @@ bool OrthotropicSym::getConstitutiveMatrix (Dune::FieldMatrix<double,6,6>& C,
   return true;
 }
 
-bool OrthotropicSym::getConstitutiveMatrix (Dune::FieldMatrix<double,3,3>& C,
-                                            bool invers) const
+bool OrthotropicSym::getConstitutiveMatrix (Dune::FieldMatrix<double,3,3>& /* C */,
+                                            bool /* invers */) const
 {
   return false;
 }

--- a/opm/elasticity/matrixops.hpp
+++ b/opm/elasticity/matrixops.hpp
@@ -12,9 +12,13 @@
 #ifndef MATRIXOPS_HPP_
 #define MATRIXOPS_HPP_
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
 #include <dune/common/fmatrix.hh> 
 #include <dune/common/dynmatrix.hh>
 #include <dune/istl/bcrsmatrix.hh>
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 namespace Opm {
 namespace Elasticity {

--- a/opm/elasticity/mpc.hh
+++ b/opm/elasticity/mpc.hh
@@ -75,9 +75,9 @@ public:
     DOF(int n, int d, double c = double(0)) : node(n), dof(d), coeff(c) {}
 
     //! \brief Global stream operator printing a DOF instance.
-    friend std::ostream& operator<<(std::ostream& s, const DOF& dof)
+    friend std::ostream& operator<<(std::ostream& s, const DOF& d)
     {
-      return s <<"u_"<< char('w'+dof.dof) <<" in node "<< dof.node;
+      return s <<"u_"<< char('w'+d.dof) <<" in node "<< d.node;
     }
 
     int  node;  //!< Node number identifying this DOF

--- a/opm/elasticity/uzawa_solver.hpp
+++ b/opm/elasticity/uzawa_solver.hpp
@@ -41,7 +41,7 @@ class UzawaSolver : public Dune::InverseOperator<X,Y>
     //! \param[in] b The load vector
     //! \param[in] reduction Ignored
     //! \param[in] res The inverse operator result
-    void apply(X& x, Y& b, double reduction, 
+    void apply(X& x, Y& b, double /* reduction */,
                Dune::InverseOperatorResult& res)
     {
       apply(x, b, res);

--- a/opm/porsol/blackoil/BlackoilInitialization.hpp
+++ b/opm/porsol/blackoil/BlackoilInitialization.hpp
@@ -117,7 +117,7 @@ namespace Opm
                             double rho = 0.5*((simstate.cell_z_[cell]+simstate.cell_z_[cell-1])*fluid.surfaceDensities());
                             double press = rho*((grid.cellCentroid(cell) - grid.cellCentroid(cell-1))*gravity) + simstate.cell_pressure_[cell-1][0];
                             simstate.cell_pressure_[cell] = PhaseVec(press);
-                            typename Fluid::FluidState state = fluid.computeState(simstate.cell_pressure_[cell], simstate.cell_z_[cell]);
+                            state = fluid.computeState(simstate.cell_pressure_[cell], simstate.cell_z_[cell]);
                             fluid_vol_dens = state.total_phase_volume_density_;
                             simstate.cell_z_[cell] *= 1.0/fluid_vol_dens;
                             ++cnt;

--- a/opm/porsol/blackoil/BlackoilInitialization.hpp
+++ b/opm/porsol/blackoil/BlackoilInitialization.hpp
@@ -273,7 +273,7 @@ namespace Opm
                               int iCell,
                               int iRef,
                               double wo_contact_depth,
-                              double go_contact_depth,
+                              double /* go_contact_depth */,
                               double connate_water_saturation,
                               double residual_oil_saturation,
                               State& simstate)

--- a/opm/porsol/blackoil/BlackoilSimulator.hpp
+++ b/opm/porsol/blackoil/BlackoilSimulator.hpp
@@ -22,8 +22,15 @@
 
 
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/grid/io/file/vtk/vtkwriter.hh>
+#include <boost/filesystem/convenience.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+
 #include <opm/core/utility/Units.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/porsol/common/BoundaryConditions.hpp>
@@ -32,8 +39,6 @@
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <boost/filesystem/convenience.hpp>
-#include <boost/lexical_cast.hpp>
 #include <iostream>
 #include <string>
 #include <vector>

--- a/opm/porsol/blackoil/BlackoilWells.hpp
+++ b/opm/porsol/blackoil/BlackoilWells.hpp
@@ -486,7 +486,7 @@ namespace Opm
         return well_cell_pressure_[cell];
     }
 
-    inline Dune::FieldVector<double, 3> BlackoilWells::injectionMixture(int cell) const
+    inline Dune::FieldVector<double, 3> BlackoilWells::injectionMixture(int /* cell */) const
     {
         return injection_mixture_;
     }

--- a/opm/porsol/blackoil/co2fluid/BlackoilCo2PVT.hpp
+++ b/opm/porsol/blackoil/co2fluid/BlackoilCo2PVT.hpp
@@ -118,7 +118,7 @@ private:
 
 // ------------ Method implementations --------------
 
-void BlackoilCo2PVT::init(Opm::DeckConstPtr deck)
+void BlackoilCo2PVT::init(Opm::DeckConstPtr /* deck */)
 {
 	surfaceDensities_[Water]   = 1000.;
 	surfaceDensities_[Gas] = 2.0;

--- a/opm/porsol/blackoil/fluid/BlackoilDefs.hpp
+++ b/opm/porsol/blackoil/fluid/BlackoilDefs.hpp
@@ -20,9 +20,12 @@
 #ifndef OPM_BLACKOILDEFS_HEADER_INCLUDED
 #define OPM_BLACKOILDEFS_HEADER_INCLUDED
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 namespace Opm
 {

--- a/opm/porsol/blackoil/fluid/FluidMatrixInteractionBlackoil.hpp
+++ b/opm/porsol/blackoil/fluid/FluidMatrixInteractionBlackoil.hpp
@@ -124,27 +124,6 @@ public:
         pc[Vapour] = params.pcog_(sg);
     }
 
-    /*!
-     * \brief The saturation-capillary pressure curve.
-     *
-     * This is the inverse of the capillary pressure-saturation curve:
-     * \f[
-     S_w = 1 - \frac{p_C - p_{C,entry}}{p_{C,max} - p_{C,entry}}
-     \f]
-     *
-     * \param pC Capillary pressure \f$\p_C\f$
-     * \return The effective saturaion of the wetting phase \f$\overline{S}_w\f$
-     */
-    template <class SatContainerT, class pcContainerT>
-    static void S(SatContainerT &saturations,
-                  const Params &params, 
-                  const pcContainerT &pc,
-                  Scalar /*temperature*/)
-    {
-        std::cerr << "FluidMatrixInteractionBlackoil::S() is not implemented yet\n";
-        throw std::logic_error("Not implemented");
-    }
-
 
     /*!
      * \brief The relative permeability of all phases.

--- a/opm/porsol/blackoil/fluid/MiscibilityDead.cpp
+++ b/opm/porsol/blackoil/fluid/MiscibilityDead.cpp
@@ -102,7 +102,7 @@ namespace Opm
     {
     }
 
-    double MiscibilityDead::getViscosity(int region, double press, const surfvol_t& /*surfvol*/) const
+    double MiscibilityDead::getViscosity(int /* region */, double press, const surfvol_t& /*surfvol*/) const
     {
 	return viscosity_(press);
     }
@@ -120,7 +120,7 @@ namespace Opm
         }
     }
 
-    double MiscibilityDead::B(int region, double press, const surfvol_t& /*surfvol*/) const
+    double MiscibilityDead::B(int /* region */, double press, const surfvol_t& /*surfvol*/) const
     {
 	// Interpolate 1/B 
 	return 1.0/one_over_B_(press);

--- a/opm/porsol/common/GridInterfaceEuler.hpp
+++ b/opm/porsol/common/GridInterfaceEuler.hpp
@@ -36,14 +36,19 @@
 #ifndef OPENRS_GRIDINTERFACEEULER_HEADER
 #define OPENRS_GRIDINTERFACEEULER_HEADER
 
-#include <dune/common/fvector.hh>
 #include <opm/core/utility/SparseTable.hpp>
 #include <opm/core/utility/StopWatch.hpp>
-#include <dune/grid/common/mcmgmapper.hh>
 #include <dune/grid/CpGrid.hpp> // How to avoid this? Needed for the explicit mapper specialization below.
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
+#include <dune/common/fvector.hh>
+#include <dune/grid/common/mcmgmapper.hh>
 
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/scoped_ptr.hpp>
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <climits>
 #include <iostream>

--- a/opm/porsol/common/ReservoirPropertyCommon_impl.hpp
+++ b/opm/porsol/common/ReservoirPropertyCommon_impl.hpp
@@ -175,6 +175,7 @@ namespace Opm
         ///
         /// @param [out] tensor
         /// @param [out] kmap
+        inline
         PermeabilityKind fillTensor(Opm::DeckConstPtr deck,
                                     std::vector<const std::vector<double>*>& tensor,
                                     std::array<int,9>&                     kmap)

--- a/opm/porsol/common/ReservoirPropertyTracerFluid.hpp
+++ b/opm/porsol/common/ReservoirPropertyTracerFluid.hpp
@@ -50,7 +50,7 @@ namespace Opm {
 
         // This one is so far only used for tensorial mobs, so we cheat a little.
         template <class ActualMobType>
-        void phaseMobility(int phase, int cell_index, double saturation, ActualMobType& mobility) const
+        void phaseMobility(int phase, int /*cell_index*/, double saturation, ActualMobType& mobility) const
         {
             double m = phase == 0 ? saturation : 1.0 - saturation;
             eye(mobility);

--- a/opm/porsol/common/SimulatorBase.hpp
+++ b/opm/porsol/common/SimulatorBase.hpp
@@ -37,8 +37,6 @@
 #define OPENRS_SIMULATORBASE_HEADER
 
 
-#include <boost/lexical_cast.hpp>
-
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 
 #include <opm/core/utility/SparseVector.hpp>
@@ -47,7 +45,6 @@
 
 #include <dune/grid/common/Volumes.hpp>
 #include <dune/grid/CpGrid.hpp>
-#include <dune/grid/yaspgrid.hh>
 
 #include <opm/porsol/common/GridInterfaceEuler.hpp>
 #include <opm/porsol/common/ReservoirPropertyCapillary.hpp>
@@ -61,6 +58,15 @@
 
 #include <opm/porsol/mimetic/MimeticIPEvaluator.hpp>
 #include <opm/porsol/mimetic/IncompFlowSolverHybrid.hpp>
+
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
+#include <boost/lexical_cast.hpp>
+#include <dune/grid/yaspgrid.hh>
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
 
 #include <fstream>
 #include <iterator>

--- a/opm/porsol/common/SimulatorBase.hpp
+++ b/opm/porsol/common/SimulatorBase.hpp
@@ -196,7 +196,7 @@ namespace Opm
 	    setupBoundaryConditions(param, ginterf_, bcond_);
 	}
 
-        virtual void initSources(const Opm::parameter::ParameterGroup& param)
+        virtual void initSources(const Opm::parameter::ParameterGroup& /* param */)
         {
             int nc = ginterf_.numberOfCells();
 	    injection_rates_ = Opm::SparseVector<double>(nc);

--- a/opm/porsol/common/SimulatorUtilities.hpp
+++ b/opm/porsol/common/SimulatorUtilities.hpp
@@ -37,10 +37,15 @@
 #define OPENRS_SIMULATORUTILITIES_HEADER
 
 
-#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
 #include <dune/common/version.hh>
 #include <dune/common/fvector.hh>
 #include <dune/grid/io/file/vtk/vtkwriter.hh>
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/common/ErrorMacros.hpp>
 #include <vector>
 #include <fstream>
 #include <algorithm>

--- a/opm/porsol/common/setupGridAndProps.hpp
+++ b/opm/porsol/common/setupGridAndProps.hpp
@@ -39,12 +39,17 @@
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/core/utility/Units.hpp>
 #include <dune/grid/CpGrid.hpp>
-#include <dune/grid/sgrid.hh>
 #include <opm/porsol/common/ReservoirPropertyCapillary.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
+#include <dune/grid/sgrid.hh>
 #include <boost/filesystem.hpp>
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 namespace Opm
 {

--- a/opm/porsol/common/setupGridAndProps.hpp
+++ b/opm/porsol/common/setupGridAndProps.hpp
@@ -46,7 +46,6 @@
 
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
 
-#include <dune/grid/sgrid.hh>
 #include <boost/filesystem.hpp>
 
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
@@ -163,35 +162,6 @@ namespace Opm
         res_prop.init(deck, grid.globalCell(), perm_threshold, rl_ptr, use_jfunction_scaling, sigma, theta);
         if (unique_bids) {
             grid.setUniqueBoundaryIds(true);
-        }
-    }
-
-    /// @brief
-    /// @todo Doc me!
-    /// @param
-    template <template <int> class ResProp>
-    inline void setupGridAndProps(const Opm::parameter::ParameterGroup& param,
-                                  Dune::SGrid<3, 3>& grid,
-                                  ResProp<3>& res_prop)
-    {
-        // Initialize grid and reservoir properties.
-        // Parts copied from Dune::CpGrid::init().
-        std::string fileformat = param.getDefault<std::string>("fileformat", "cartesian");
-        if (fileformat == "cartesian") {
-            std::array<int, 3> dims = {{ param.getDefault<int>("nx", 1),
-                                    param.getDefault<int>("ny", 1),
-                                    param.getDefault<int>("nz", 1) }};
-            std::array<double, 3> cellsz = {{ param.getDefault<double>("dx", 1.0),
-                                         param.getDefault<double>("dy", 1.0),
-                                         param.getDefault<double>("dz", 1.0) }};
-            grid.~SGrid<3,3>();
-            new (&grid) Dune::SGrid<3, 3>(&dims[0], &cellsz[0]);
-            double default_poro = param.getDefault("default_poro", 0.2);
-            double default_perm = param.getDefault("default_perm", 100.0*Opm::prefix::milli*Opm::unit::darcy);
-            OPM_MESSAGE("Warning: For generated cartesian grids, we use uniform reservoir properties.");
-            res_prop.init(grid.size(0), default_poro, default_perm);
-        } else {
-            OPM_THROW(std::runtime_error, "Dune::SGrid can only handle cartesian grids, unsupported file format string: " << fileformat);
         }
     }
 

--- a/opm/porsol/euler/EulerUpstreamImplicit_impl.hpp
+++ b/opm/porsol/euler/EulerUpstreamImplicit_impl.hpp
@@ -228,9 +228,9 @@ namespace Opm
     template <class PressureSolution>
     bool EulerUpstreamImplicit<GI, RP, BC>::transportSolve(std::vector<double>& saturation,
                                                            const double time,
-                                                           const typename GI::Vector& gravity,
+                                                           const typename GI::Vector& /* gravity */,
                                                            const PressureSolution& pressure_sol,
-                                                           const Opm::SparseVector<double>& injection_rates) const
+                                                           const Opm::SparseVector<double>& /* injection_rates */) const
     {
 
         Opm::ReservoirState<2> state(mygrid_.c_grid());

--- a/opm/porsol/euler/EulerUpstreamResidual.hpp
+++ b/opm/porsol/euler/EulerUpstreamResidual.hpp
@@ -101,7 +101,7 @@ namespace Opm {
 	void initFinal();
 
 	typename GridInterface::Vector
-	estimateCapPressureGradient(const FIt& f, const FIt& nbf, const std::vector<double>& saturation) const;
+	estimateCapPressureGradient(const FIt& f, const FIt& nbf) const;
 
 	const GridInterface* pgrid_;
 	const ReservoirProperties* preservoir_properties_;

--- a/opm/porsol/euler/EulerUpstreamResidual_impl.hpp
+++ b/opm/porsol/euler/EulerUpstreamResidual_impl.hpp
@@ -268,15 +268,9 @@ namespace Opm
                     if (s.method_capillary_) {
                         // J(s_w) = \frac{p_c(s_w)\sqrt{k/\phi}}{\sigma \cos\theta}
                         // p_c = \frac{J \sigma \cos\theta}{\sqrt{k/\phi}}
-                        Vector cap_influence = prod(aver_perm, s.estimateCapPressureGradient(f, nbface, saturation));
+                        Vector cap_influence = prod(aver_perm, s.estimateCapPressureGradient(f, nbface));
                         const double cap_change = loc_area
 			    *inner(loc_normal, m_aver[0].multiply(m_aver_totinv.multiply(m_aver[1].multiply(cap_influence))));
-                        // 		    const double cap_vel = inner(loc_normal, prod(aver_perm, estimateCapPressureGradient(f, nbface, saturation)));
-                        // 		    const double loc_cap_flux = cap_vel*loc_area;
-                        // //   		    const double cap_change = loc_cap_flux*(m_aver[1].mob*m_aver[0].mob
-                        // //   							    /(m_aver[0].mob + m_aver[1].mob));
-                        //  		    const double cap_change = loc_cap_flux*(aver_lambda_two*aver_lambda_one
-                        //  							    /(aver_lambda_one + aver_lambda_two));
                         dS += cap_change;
                     }
 
@@ -510,7 +504,7 @@ namespace Opm
     template <class GI, class RP, class BC>
     inline typename GI::Vector
     EulerUpstreamResidual<GI, RP, BC>::
-    estimateCapPressureGradient(const FIt& f, const FIt& nbf, const std::vector<double>& saturation) const
+    estimateCapPressureGradient(const FIt& f, const FIt& nbf) const
     {
 	typedef typename GI::CellIterator::FaceIterator Face;
 	typedef typename Face::Cell Cell;

--- a/opm/porsol/mimetic/IncompFlowSolverHybrid.hpp
+++ b/opm/porsol/mimetic/IncompFlowSolverHybrid.hpp
@@ -1513,8 +1513,10 @@ namespace Opm {
 #endif
                 criterion.setProlongationDampingFactor(prolong_factor);
                 criterion.setBeta(1e-10);
-                precond_.reset(new Precond(*opS_, criterion, smootherArgs,
-				           1, smooth_steps, smooth_steps));
+                criterion.setNoPreSmoothSteps(smooth_steps);
+                criterion.setNoPostSmoothSteps(smooth_steps);
+                criterion.setGamma(1); // V-cycle; this is the default
+                precond_.reset(new Precond(*opS_, criterion, smootherArgs));
             }
             // Construct solver for system of linear equations.
             Dune::CGSolver<Vector> linsolve(*opS_, dynamic_cast<Precond&>(*precond_), residTol, (maxit>0)?maxit:S_.N(), verbosity_level);

--- a/opm/porsol/mimetic/IncompFlowSolverHybrid.hpp
+++ b/opm/porsol/mimetic/IncompFlowSolverHybrid.hpp
@@ -38,22 +38,25 @@
 #ifndef OPENRS_INCOMPFLOWSOLVERHYBRID_HEADER
 #define OPENRS_INCOMPFLOWSOLVERHYBRID_HEADER
 
-#include <boost/unordered_map.hpp>
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/core/utility/SparseTable.hpp>
+#include <opm/porsol/common/BoundaryConditions.hpp>
+#include <opm/porsol/common/Matrix.hpp>
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
+#include <boost/unordered_map.hpp>
 #include <boost/bind.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/lexical_cast.hpp>
 
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
-#include <opm/common/ErrorMacros.hpp>
-#include <opm/core/utility/SparseTable.hpp>
 
 #include <dune/istl/bvector.hh>
 #include <dune/istl/bcrsmatrix.hh>
 #include <dune/istl/operators.hh>
 #include <dune/istl/io.hh>
-
 #include <dune/istl/overlappingschwarz.hh>
 #include <dune/istl/schwarz.hh>
 #include <dune/istl/preconditioners.hh>
@@ -67,8 +70,8 @@
 #include <dune/istl/paamg/kamg.hh>
 #include <dune/istl/paamg/pinfo.hh>
 
-#include <opm/porsol/common/BoundaryConditions.hpp>
-#include <opm/porsol/common/Matrix.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
 
 #include <algorithm>
 #include <functional>

--- a/opm/porsol/mimetic/TpfaCompressibleAssembler.hpp
+++ b/opm/porsol/mimetic/TpfaCompressibleAssembler.hpp
@@ -162,7 +162,7 @@ public:
                   const double* cell_pressure,
                   const double* gravcapf,
                   const double* wellperf_gpot,
-                  const double* surf_dens)
+                  const double* /* surf_dens */)
     {
         if (state_ == Uninitialized) {
             throw std::runtime_error("Error in TpfaCompressibleAssembler::assemble(): You must call init() prior to calling assemble().");

--- a/opm/upscaling/RelPermUtils.cpp
+++ b/opm/upscaling/RelPermUtils.cpp
@@ -768,7 +768,7 @@ std::tuple<double, double>
 
             double Ptestvalue = pressurePoints[pointidx];
 
-            std::array<double,2> maxPhasePerm({0.0, 0.0});
+            std::array<double,2> maxPhasePerm{{0.0, 0.0}};
             std::array<std::vector<double>,2> phasePermValues;
             std::array<std::vector<std::vector<double>>,2> phasePermValuesDiag;
             std::array<double,2> minPhasePerm;

--- a/opm/upscaling/RelPermUtils.cpp
+++ b/opm/upscaling/RelPermUtils.cpp
@@ -281,15 +281,15 @@ void RelPermUpscaleHelper::sanityCheckInput(Opm::DeckConstPtr deck,
     int cells_truncated_from_below_poro = 0;
     int cells_truncated_from_below_permx = 0;
     int cells_truncated_from_above_permx = 0;
-    auto it = std::find_if(satnums.begin(), satnums.end(), [](int a) { return a < 0; });
+    auto it1 = std::find_if(satnums.begin(), satnums.end(), [](int a) { return a < 0; });
     auto it2 = std::find_if(satnums.begin(), satnums.end(), [](int a) { return a > 1000;});
-    if (it != satnums.end() || it2 != satnums.end()) {
+    if (it1 != satnums.end() || it2 != satnums.end()) {
         std::stringstream str;
         str << "satnums[";
-        if (it == satnums.end())
+        if (it1 == satnums.end())
             str << it2-satnums.begin() << "] = " << *it2;
         else
-            str << it-satnums.begin() << "] = " << *it;
+            str << it1-satnums.begin() << "] = " << *it1;
         str << ", not sane, quitting.";
         throw std::runtime_error(str.str());
     }
@@ -298,7 +298,7 @@ void RelPermUpscaleHelper::sanityCheckInput(Opm::DeckConstPtr deck,
     auto it3 = std::find_if(poros.begin(), poros.end(), find_error_both);
     if (it3 != poros.end()) {
         std::stringstream str;
-        str << "poros[" << it3-poros.begin() <<"] = " << *it << ", not sane, quitting.";
+        str << "poros[" << it3-poros.begin() <<"] = " << *it3 << ", not sane, quitting.";
         throw std::runtime_error(str.str());
     }
     auto&& find_error_below = [](double value) { return value < 0; };

--- a/opm/upscaling/SteadyStateUpscalerImplicit_impl.hpp
+++ b/opm/upscaling/SteadyStateUpscalerImplicit_impl.hpp
@@ -260,7 +260,6 @@ namespace Opm
                     Opm::writeECLData(*grid_adapter_.c_grid(), datamap, it_count, ecl_time, ecl_curdate, "./", basename);
                 }
                 // Comparing old to new.
-                int num_cells = saturation.size();
                 double maxdiff = 0.0;
                 double euclidean_diff = 0.0;
                 for (int i = 0; i < num_cells; ++i) {


### PR DESCRIPTION
With this only a few warnings remain for me in this module. I'll list them since they are not trivially fixed and may point to real issues.

 - Shadowing warnings: in elasticity_upscale_impl.hpp lines 308, 501, 561 and 734.
 - "format string is not a string literal" in upscale_elasticity.cpp lines 382, 389 and 396. The sprintf() calls look strange, and depending on user commandline input correctly containing indicators for string and numeric arguments! Also, the first one loads, the two others stores a matrix. Is that correct?
 - Deprecated Mapper::map() in Dune. Should use index() instead, but I think that is not available before 2.4 so we must keep map() until we can drop 2.3. Found in elasticity_upscale_impl.hpp lines 45 and 381.
 - Deprecated recalc_defect argument, elasticity_upscale_impl.hpp line 1040.