### PR TITLE
Chase EclipseState::getTableManager() Return Type Update

### DIFF
--- a/opm/porsol/blackoil/fluid/BlackoilPVT.cpp
+++ b/opm/porsol/blackoil/fluid/BlackoilPVT.cpp
@@ -67,8 +67,8 @@ namespace Opm
 
         // Oil PVT
         const auto& tables     = eclipseState->getTableManager();
-        const auto& pvdoTables = tables->getPvdoTables();
-        const auto& pvtoTables = tables->getPvtoTables();
+        const auto& pvdoTables = tables.getPvdoTables();
+        const auto& pvtoTables = tables.getPvtoTables();
         if (!pvdoTables.empty()) {
             const auto& pvdoTable = pvdoTables.getTable<PvdoTable>(0);
             oil_props_.reset(new MiscibilityDead(pvdoTable));
@@ -85,8 +85,8 @@ namespace Opm
         }
 
 	// Gas PVT
-        const auto& pvdgTables = tables->getPvdgTables();
-        const auto& pvtgTables = tables->getPvtgTables();
+        const auto& pvdgTables = tables.getPvdgTables();
+        const auto& pvtgTables = tables.getPvtgTables();
         if (!pvdgTables.empty()) {
             const auto& pvdgTable = pvdgTables.getTable<PvdgTable>(0);
             gas_props_.reset(new MiscibilityDead(pvdgTable));

--- a/opm/porsol/blackoil/fluid/FluidMatrixInteractionBlackoil.hpp
+++ b/opm/porsol/blackoil/fluid/FluidMatrixInteractionBlackoil.hpp
@@ -50,8 +50,8 @@ public:
         EclipseState eclipseState(deck , parseContext);
         // Extract input data.
         const auto& tables    = eclipseState.getTableManager();
-        const auto& swofTable = tables->getSwofTables().getTable<SwofTable>(0);
-        const auto& sgofTable = tables->getSgofTables().getTable<SgofTable>(0);
+        const auto& swofTable = tables.getSwofTables().getTable<SwofTable>(0);
+        const auto& sgofTable = tables.getSgofTables().getTable<SgofTable>(0);
 
         std::vector<double> sw = swofTable.getSwColumn().vectorCopy();
         std::vector<double> krw = swofTable.getKrwColumn().vectorCopy();


### PR DESCRIPTION
The return type of `EclipseState::getTableManager()` changed from
```C++
std::shared_ptr<const TableManager>
```
to
```C++
const TableManager&
```
in commit OPM/opm-parser@4d4be1d (PR OPM/opm-parser#751).  Update callers accordingly.