### PR TITLE
Capillary gravity upscaling

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -31,6 +31,7 @@
 list (APPEND TEST_SOURCE_FILES
 	tests/common/boundaryconditions_test.cpp
 	tests/common/matrix_test.cpp
+	tests/common/test_gravitypressure.cpp
 	)
 
 list(APPEND MAIN_SOURCE_FILES

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -34,6 +34,7 @@ list (APPEND TEST_SOURCE_FILES
 	)
 
 list(APPEND MAIN_SOURCE_FILES
+	opm/upscaling/ParserAdditions.cpp
 	opm/upscaling/RelPermUtils.cpp
 	opm/porsol/blackoil/fluid/BlackoilPVT.cpp
 	opm/porsol/blackoil/fluid/MiscibilityDead.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -34,8 +34,6 @@ list (APPEND TEST_SOURCE_FILES
 	)
 
 list(APPEND MAIN_SOURCE_FILES
-	opm/upscaling/ParserAdditions.cpp
-	opm/upscaling/RelPermUtils.cpp
 	opm/porsol/blackoil/fluid/BlackoilPVT.cpp
 	opm/porsol/blackoil/fluid/MiscibilityDead.cpp
 	opm/porsol/blackoil/fluid/MiscibilityLiveGas.cpp
@@ -46,6 +44,8 @@ list(APPEND MAIN_SOURCE_FILES
 	opm/porsol/common/ImplicitTransportDefs.cpp
 	opm/porsol/common/setupGridAndProps.cpp
 	opm/porsol/euler/ImplicitCapillarity.cpp
+	opm/upscaling/ParserAdditions.cpp
+	opm/upscaling/RelPermUtils.cpp
 	)
 
 # originally generated with the command:
@@ -80,11 +80,23 @@ list (APPEND TEST_DATA_FILES
 # originally generated with the command:
 # find examples -name '*.c*' -a ! -name 'twophase2_test.cpp' -printf '\t%p\n' | sort
 list (APPEND EXAMPLE_SOURCE_FILES
+	examples/aniso_implicitcap_test.cpp
+	examples/aniso_simulator_test.cpp
+	examples/co2_blackoil_pvt.cpp
 	examples/cpchop.cpp
 	examples/cpchop_depthtrend.cpp
 	examples/cpregularize.cpp
 	examples/exp_variogram.cpp
 	examples/grdecldips.cpp
+	examples/implicitcap_test.cpp
+	examples/known_answer_test.cpp
+	examples/mimetic_aniso_solver_test.cpp
+	examples/mimetic_periodic_test.cpp
+	examples/mimetic_solver_test.cpp
+	examples/sim_blackoil_impes.cpp
+	examples/sim_co2_impes.cpp
+	examples/sim_steadystate_explicit.cpp
+	examples/sim_steadystate_implicit.cpp
 	examples/steadystate_test_implicit.cpp
 	examples/upscale_avg.cpp
 	examples/upscale_cap.cpp
@@ -95,23 +107,11 @@ list (APPEND EXAMPLE_SOURCE_FILES
 	examples/upscale_singlephase.cpp
 	examples/upscale_steadystate_implicit.cpp
 	tests/compare_upscaling_results.cpp
-	examples/aniso_implicitcap_test.cpp
-	examples/aniso_simulator_test.cpp
-	examples/co2_blackoil_pvt.cpp
-	examples/implicitcap_test.cpp
-	examples/known_answer_test.cpp
-	examples/mimetic_aniso_solver_test.cpp
-	examples/mimetic_periodic_test.cpp
-	examples/mimetic_solver_test.cpp
-	examples/sim_blackoil_impes.cpp
-	examples/sim_co2_impes.cpp
-	examples/sim_steadystate_explicit.cpp
-	examples/sim_steadystate_implicit.cpp
 	)
 
 list (APPEND ADDITIONAL_SOURCE_FILES
-  benchmarks/upscale_relperm_benchmark.cpp
-	   )
+	benchmarks/upscale_relperm_benchmark.cpp
+	)
 
 # originally generated with the command:
 # find attic -name '*.c*' -printf '\t%p\n' | sort
@@ -130,6 +130,8 @@ list (APPEND PROGRAM_SOURCE_FILES
 	examples/cpregularize.cpp
 	examples/exp_variogram.cpp
 	examples/grdecldips.cpp
+	examples/sim_blackoil_impes.cpp
+	examples/sim_co2_impes.cpp
 	examples/steadystate_test_implicit.cpp
 	examples/upscale_avg.cpp
 	examples/upscale_cap.cpp
@@ -139,24 +141,11 @@ list (APPEND PROGRAM_SOURCE_FILES
 	examples/upscale_relpermvisc.cpp
 	examples/upscale_singlephase.cpp
 	examples/upscale_steadystate_implicit.cpp
-	examples/sim_blackoil_impes.cpp
-	examples/sim_co2_impes.cpp
 	)
 
 # originally generated with the command:
 # find opm -name '*.h*' -a ! -name '*-pch.hpp' -printf '\t%p\n' | sort
 list (APPEND PUBLIC_HEADER_FILES
-	opm/upscaling/ParserAdditions.hpp
-	opm/upscaling/SinglePhaseUpscaler.hpp
-	opm/upscaling/SteadyStateUpscaler.hpp
-	opm/upscaling/SteadyStateUpscaler_impl.hpp
-	opm/upscaling/SteadyStateUpscalerImplicit.hpp
-	opm/upscaling/SteadyStateUpscalerImplicit_impl.hpp
-	opm/upscaling/SteadyStateUpscalerManager.hpp
-	opm/upscaling/SteadyStateUpscalerManagerImplicit.hpp
-	opm/upscaling/UpscalerBase.hpp
-	opm/upscaling/UpscalerBase_impl.hpp
-	opm/upscaling/UpscalingTraits.hpp
 	opm/porsol/blackoil/BlackoilFluid.hpp
 	opm/porsol/blackoil/BlackoilInitialization.hpp
 	opm/porsol/blackoil/BlackoilSimulator.hpp
@@ -215,6 +204,17 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/porsol/mimetic/IncompFlowSolverHybrid.hpp
 	opm/porsol/mimetic/MimeticIPAnisoRelpermEvaluator.hpp
 	opm/porsol/mimetic/MimeticIPEvaluator.hpp
-	opm/porsol/mimetic/TpfaCompressible.hpp
 	opm/porsol/mimetic/TpfaCompressibleAssembler.hpp
+	opm/porsol/mimetic/TpfaCompressible.hpp
+	opm/upscaling/ParserAdditions.hpp
+	opm/upscaling/SinglePhaseUpscaler.hpp
+	opm/upscaling/SteadyStateUpscaler.hpp
+	opm/upscaling/SteadyStateUpscaler_impl.hpp
+	opm/upscaling/SteadyStateUpscalerImplicit.hpp
+	opm/upscaling/SteadyStateUpscalerImplicit_impl.hpp
+	opm/upscaling/SteadyStateUpscalerManager.hpp
+	opm/upscaling/SteadyStateUpscalerManagerImplicit.hpp
+	opm/upscaling/UpscalerBase.hpp
+	opm/upscaling/UpscalerBase_impl.hpp
+	opm/upscaling/UpscalingTraits.hpp
 	)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -43,6 +43,7 @@ list(APPEND MAIN_SOURCE_FILES
 	opm/porsol/blackoil/fluid/MiscibilityProps.cpp
 	opm/porsol/common/blas_lapack.cpp
 	opm/porsol/common/BoundaryPeriodicity.cpp
+	opm/porsol/common/ImplicitTransportDefs.cpp
 	opm/porsol/common/setupGridAndProps.cpp
 	opm/porsol/euler/ImplicitCapillarity.cpp
 	)

--- a/examples/aniso_implicitcap_test.cpp
+++ b/examples/aniso_implicitcap_test.cpp
@@ -33,20 +33,27 @@
   along with OpenRS.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
-#define VERBOSE
-//#define USE_TBB
-
 #include "config.h"
 
-#include "SimulatorTester.hpp"
-#include "SimulatorTesterFlexibleBC.hpp"
-#include <opm/porsol/common/SimulatorTraits.hpp>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
+#include <dune/common/version.hh>
+
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
 #else
 #include <dune/common/mpihelper.hh>
 #endif
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#define VERBOSE
+//#define USE_TBB
+
+#include "SimulatorTester.hpp"
+#include "SimulatorTesterFlexibleBC.hpp"
+
+#include <opm/porsol/common/SimulatorTraits.hpp>
 
 #ifdef USE_TBB
 #include <tbb/task_scheduler_init.h>
@@ -64,10 +71,12 @@ try
 {
     Opm::parameter::ParameterGroup param(argc, argv);
     Dune::MPIHelper::instance(argc,argv);
+
 #ifdef USE_TBB
     int num_threads = param.getDefault("num_threads", tbb::task_scheduler_init::default_num_threads());
     tbb::task_scheduler_init init(num_threads);
 #endif
+
     Simulator sim;
     sim.init(param);
     sim.run();

--- a/examples/aniso_simulator_test.cpp
+++ b/examples/aniso_simulator_test.cpp
@@ -39,14 +39,22 @@
 
 #include "config.h"
 
-#include "SimulatorTester.hpp"
-#include "SimulatorTesterFlexibleBC.hpp"
-#include <opm/porsol/common/SimulatorTraits.hpp>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
+#include <dune/common/version.hh>
+
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
 #else
 #include <dune/common/mpihelper.hh>
 #endif
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include "SimulatorTester.hpp"
+#include "SimulatorTesterFlexibleBC.hpp"
+
+#include <opm/porsol/common/SimulatorTraits.hpp>
 
 #ifdef USE_TBB
 #include <tbb/task_scheduler_init.h>
@@ -64,10 +72,12 @@ try
 {
     Opm::parameter::ParameterGroup param(argc, argv);
     Dune::MPIHelper::instance(argc,argv);
+
 #ifdef USE_TBB
     int num_threads = param.getDefault("num_threads", tbb::task_scheduler_init::default_num_threads());
     tbb::task_scheduler_init init(num_threads);
 #endif
+
     Simulator sim;
     sim.init(param);
     sim.run();

--- a/examples/co2_blackoil_pvt.cpp
+++ b/examples/co2_blackoil_pvt.cpp
@@ -17,8 +17,6 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
-
 #include "config.h"
 
 #include <opm/core/utility/StopWatch.hpp>
@@ -30,20 +28,24 @@ int main(int argc, char** argv)
 try
 {
     double temperature = 300.;
-    if (argc == 2) temperature = std::atof(argv[1]);
+    if (argc == 2) {
+        temperature = std::atof(argv[1]);
+    }
 
     Opm::BlackoilCo2PVT boPvt;
     Opm::DeckConstPtr deck; // <- uninitalized pointer!
     Opm::time::StopWatch clock;
-  clock.start();
+
+    clock.start();
     boPvt.init(deck);
 
     boPvt.generateBlackOilTables(temperature);
-  clock.stop();
-  std::cout << "\n\nInitialisation and table generation - clock time (secs): " << clock.secsSinceStart() << std::endl;
+    clock.stop();
+
+    std::cout << "\n\nInitialisation and table generation - clock time (secs): "
+              << clock.secsSinceStart() << std::endl;
 }
 catch (const std::exception &e) {
     std::cerr << "Program threw an exception: " << e.what() << "\n";
     throw;
 }
-

--- a/examples/cpchop.cpp
+++ b/examples/cpchop.cpp
@@ -19,34 +19,43 @@
 */
 #include <config.h>
 
-#include <opm/output/eclipse/CornerpointChopper.hpp>
-#include <opm/output/eclipse/EclipseGridInspector.hpp>
-#include <opm/upscaling/SinglePhaseUpscaler.hpp>
-#include <opm/core/utility/MonotCubicInterpolator.hpp>
-#include <opm/porsol/common/setupBoundaryConditions.hpp>
-#include <opm/core/utility/Units.hpp>
-
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/uniform_int.hpp>
-#include <boost/random/uniform_real.hpp>
-#include <boost/random/variate_generator.hpp>
-
-#include <ios>
-#include <iomanip>
-#include <sys/utsname.h>
-#include <ctime>
-#include <sstream>
-#include <fstream>
-#include <iostream>
-#include <cfloat>
-#include <cmath>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
+
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
 #else
 #include <dune/common/mpihelper.hh>
 #endif
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/core/utility/MonotCubicInterpolator.hpp>
+#include <opm/core/utility/Units.hpp>
+
+#include <opm/output/eclipse/CornerpointChopper.hpp>
+#include <opm/output/eclipse/EclipseGridInspector.hpp>
+
+#include <opm/porsol/common/setupBoundaryConditions.hpp>
+
+#include <opm/upscaling/SinglePhaseUpscaler.hpp>
+
+#include <cfloat>
+#include <cmath>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <ios>
+#include <iostream>
+#include <sstream>
+
+#include <sys/utsname.h>
+
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int.hpp>
+#include <boost/random/uniform_real.hpp>
+#include <boost/random/variate_generator.hpp>
 
 int main(int argc, char** argv)
 try

--- a/examples/cpchop_depthtrend.cpp
+++ b/examples/cpchop_depthtrend.cpp
@@ -16,34 +16,43 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include <config.h>
 
-
-#include <opm/output/eclipse/CornerpointChopper.hpp>
-#include <opm/upscaling/SinglePhaseUpscaler.hpp>
-#include <opm/porsol/common/setupBoundaryConditions.hpp>
-#include <opm/core/utility/Units.hpp>
-
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/uniform_int.hpp>
-#include <boost/random/uniform_real.hpp>
-#include <boost/random/variate_generator.hpp>
-
-#include <ios>
-#include <iomanip>
-#include <sys/utsname.h>
-#include <cmath> // for min()
-#include <ctime>
-#include <sstream>
-#include <fstream>
-#include <iostream>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
+
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
 #else
 #include <dune/common/mpihelper.hh>
 #endif
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/core/utility/Units.hpp>
+
+#include <opm/output/eclipse/CornerpointChopper.hpp>
+
+#include <opm/porsol/common/setupBoundaryConditions.hpp>
+
+#include <opm/upscaling/SinglePhaseUpscaler.hpp>
+
+#include <cmath> // for min()
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <ios>
+#include <iostream>
+#include <sstream>
+
+#include <sys/utsname.h>
+
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int.hpp>
+#include <boost/random/uniform_real.hpp>
+#include <boost/random/variate_generator.hpp>
 
 /**
    This program is a variant of cpchop. Instead of subsampling randomly, 

--- a/examples/cpregularize.cpp
+++ b/examples/cpregularize.cpp
@@ -32,32 +32,42 @@
    - Be careful with non-flat top and bottom boundary.
 
 */
-#include <config.h>
 
-#include <opm/output/eclipse/CornerpointChopper.hpp>
-#include <opm/output/eclipse/EclipseGridInspector.hpp>
-#include <opm/upscaling/SinglePhaseUpscaler.hpp>
-#include <opm/porsol/common/setupBoundaryConditions.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <config.h>
 
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
-#include <ios>
-#include <iomanip>
-#include <sys/utsname.h>
-#include <ctime>
-#include <sstream>
-#include <fstream>
-#include <iostream>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
+
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
 #else
 #include <dune/common/mpihelper.hh>
 #endif
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/core/utility/Units.hpp>
+
+#include <opm/output/eclipse/CornerpointChopper.hpp>
+#include <opm/output/eclipse/EclipseGridInspector.hpp>
+
+#include <opm/porsol/common/setupBoundaryConditions.hpp>
+
+#include <opm/upscaling/SinglePhaseUpscaler.hpp>
+
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <ios>
+#include <iostream>
+#include <sstream>
+
+#include <sys/utsname.h>
 
 int main(int argc, char** argv)
 try

--- a/examples/exp_variogram.cpp
+++ b/examples/exp_variogram.cpp
@@ -27,28 +27,11 @@
   difference in their properties (poro or perm)
 
   Direction for pairing is set from the command line
-
 */
+
 #include <config.h>
 
-#include <opm/output/eclipse/CornerpointChopper.hpp>
-#include <opm/upscaling/SinglePhaseUpscaler.hpp>
-#include <opm/porsol/common/setupBoundaryConditions.hpp>
-#include <opm/core/utility/Units.hpp>
-
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/uniform_int.hpp>
-#include <boost/random/uniform_real.hpp>
-#include <boost/random/variate_generator.hpp>
-
-#include <ios>
-#include <iomanip>
-#include <sys/utsname.h>
-#include <ctime>
-#include <cmath>
-#include <sstream>
-#include <fstream>
-#include <iostream>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
@@ -56,6 +39,31 @@
 #else
 #include <dune/common/mpihelper.hh>
 #endif
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/core/utility/Units.hpp>
+
+#include <opm/output/eclipse/CornerpointChopper.hpp>
+
+#include <opm/porsol/common/setupBoundaryConditions.hpp>
+
+#include <opm/upscaling/SinglePhaseUpscaler.hpp>
+
+#include <cmath>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <ios>
+#include <iostream>
+#include <sstream>
+
+#include <sys/utsname.h>
+
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int.hpp>
+#include <boost/random/uniform_real.hpp>
+#include <boost/random/variate_generator.hpp>
 
 int main(int argc, char** argv)
 try

--- a/examples/grdecldips.cpp
+++ b/examples/grdecldips.cpp
@@ -1,4 +1,3 @@
-
 /*
   Copyright 2011 Statoil ASA.
 
@@ -17,32 +16,41 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include <config.h>
 
-#include <map>
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <iomanip>
-#include <ctime>
-#include <cmath>
-#include <numeric>
-#include <sys/utsname.h>
-
-#include <opm/output/eclipse/EclipseGridInspector.hpp>
-#include <opm/core/utility/parameters/ParameterGroup.hpp>
-
-#include <opm/output/eclipse/CornerpointChopper.hpp>
-#include <opm/upscaling/SinglePhaseUpscaler.hpp>
-#include <opm/porsol/common/setupBoundaryConditions.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
+
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
 #else
 #include <dune/common/mpihelper.hh>
 #endif
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/core/utility/parameters/ParameterGroup.hpp>
+#include <opm/core/utility/Units.hpp>
+
+#include <opm/output/eclipse/CornerpointChopper.hpp>
+#include <opm/output/eclipse/EclipseGridInspector.hpp>
+
+#include <opm/porsol/common/setupBoundaryConditions.hpp>
+
+#include <opm/upscaling/SinglePhaseUpscaler.hpp>
+
+#include <cmath>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <numeric>
+#include <sstream>
+
+#include <sys/utsname.h>
 
 using namespace std;
 

--- a/examples/grdecldips.cpp
+++ b/examples/grdecldips.cpp
@@ -39,6 +39,7 @@
 
 #include <opm/porsol/common/setupBoundaryConditions.hpp>
 
+#include <opm/upscaling/RelPermUtils.hpp>
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
 
 #include <cmath>
@@ -77,9 +78,7 @@ int main(int argc, char** argv) try {
 	param.displayUsage();
     }
 
-    Opm::ParseContext parseMode;
-    Opm::ParserPtr parser(new Opm::Parser());
-    Opm::DeckConstPtr deck(parser->parseFile(gridfilename , parseMode));
+    auto deck = Opm::RelPermUpscaleHelper::parseEclipseFile(gridfilename);
     Opm::EclipseGridInspector gridinspector(deck);
     
     // Check that we have the information we need from the eclipse file, we will check PERM-fields later

--- a/examples/implicitcap_test.cpp
+++ b/examples/implicitcap_test.cpp
@@ -33,22 +33,27 @@
   along with OpenRS.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #define VERBOSE
 //#define USE_TBB
 
 #include "config.h"
 
-#include "SimulatorTester.hpp"
-#include "SimulatorTesterFlexibleBC.hpp"
-#include <opm/porsol/common/SimulatorTraits.hpp>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
+
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
 #else
 #include <dune/common/mpihelper.hh>
 #endif
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include "SimulatorTester.hpp"
+#include "SimulatorTesterFlexibleBC.hpp"
+
+#include <opm/porsol/common/SimulatorTraits.hpp>
 
 #ifdef USE_TBB
 #include <tbb/task_scheduler_init.h>
@@ -66,10 +71,12 @@ try
 {
     Opm::parameter::ParameterGroup param(argc, argv);
     Dune::MPIHelper::instance(argc,argv);
+
 #ifdef USE_TBB
     int num_threads = param.getDefault("num_threads", tbb::task_scheduler_init::default_num_threads());
     tbb::task_scheduler_init init(num_threads);
 #endif
+
     Simulator sim;
     sim.init(param);
     sim.run();

--- a/examples/mimetic_aniso_solver_test.cpp
+++ b/examples/mimetic_aniso_solver_test.cpp
@@ -35,41 +35,78 @@
 
 #include "config.h"
 
-#include <opm/core/utility/Units.hpp>
-
-#include <dune/grid/CpGrid.hpp>
-#include <opm/output/eclipse/EclipseGridInspector.hpp>
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/porsol/common/fortran.hpp>
-#include <opm/porsol/common/blas_lapack.hpp>
-#include <opm/porsol/common/Matrix.hpp>
-#include <opm/porsol/common/GridInterfaceEuler.hpp>
-#include <opm/porsol/common/ReservoirPropertyCapillaryAnisotropicRelperm.hpp>
-#include <opm/porsol/common/BoundaryConditions.hpp>
-#include <opm/porsol/mimetic/MimeticIPAnisoRelpermEvaluator.hpp>
-#include <opm/porsol/mimetic/IncompFlowSolverHybrid.hpp>
-#include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
-#include <algorithm>
-#include <iostream>
-#include <iomanip>
-#include <array>
-
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
 
-#include <dune/grid/yaspgrid.hh>
-
 #include <dune/common/version.hh>
+
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
 #else
 #include <dune/common/mpihelper.hh>
 #endif
 
+#include <dune/grid/yaspgrid.hh>
+
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <dune/grid/CpGrid.hpp>
+
+#include <opm/core/utility/Units.hpp>
+#include <opm/core/utility/parameters/ParameterGroup.hpp>
+
+#include <opm/output/eclipse/EclipseGridInspector.hpp>
+
+#include <opm/porsol/common/BoundaryConditions.hpp>
+#include <opm/porsol/common/GridInterfaceEuler.hpp>
+#include <opm/porsol/common/Matrix.hpp>
+#include <opm/porsol/common/ReservoirPropertyCapillaryAnisotropicRelperm.hpp>
+#include <opm/porsol/common/blas_lapack.hpp>
+#include <opm/porsol/common/fortran.hpp>
+#include <opm/porsol/mimetic/IncompFlowSolverHybrid.hpp>
+#include <opm/porsol/mimetic/MimeticIPAnisoRelpermEvaluator.hpp>
+
+#include <algorithm>
+#include <array>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+
+namespace
+{
+    void build_grid(Opm::DeckConstPtr  deck,
+                    const double       z_tol,
+                    Dune::CpGrid&      grid,
+                    std::array<int,3>& cartDims)
+    {
+        auto g = grdecl{};
+        {
+            const auto insp = Opm::EclipseGridInspector(deck);
+
+            cartDims[0] = g.dims[0] = insp.gridSize()[0];
+            cartDims[1] = g.dims[1] = insp.gridSize()[1];
+            cartDims[2] = g.dims[2] = insp.gridSize()[2];
+        }
+
+        g.coord = &deck->getKeyword("COORD").getSIDoubleData()[0];
+        g.zcorn = &deck->getKeyword("ZCORN").getSIDoubleData()[0];
+
+        if (deck->hasKeyword("ACTNUM")) {
+            g.actnum = &deck->getKeyword("ACTNUM").getIntData()[0];
+            grid.processEclipseFormat(g, z_tol, false, false);
+        }
+        else {
+            const auto dflt_actnum =
+                std::vector<int>(g.dims[0] * g.dims[1] * g.dims[2], 1);
+
+            g.actnum = dflt_actnum.data();
+            grid.processEclipseFormat(g, z_tol, false, false);
+        }
+    }
+} // namespace anonymous
 
 
 template <int dim, class Interface>
@@ -89,8 +126,9 @@ void test_evaluator(const Interface& g)
         numf.push_back(0);
         int& nf = numf.back();
 
-        for (FI f = c->facebegin(); f != c->faceend(); ++f)
+        for (FI f = c->facebegin(); f != c->faceend(); ++f) {
             ++nf;
+        }
 
         max_nf = std::max(max_nf, nf);
     }
@@ -121,36 +159,11 @@ void test_evaluator(const Interface& g)
 }
 
 
-void build_grid(Opm::DeckConstPtr deck,
-                const double z_tol, Dune::CpGrid& grid,
-                std::array<int,3>& cartDims)
-{
-    Opm::EclipseGridInspector insp(deck);
-
-    grdecl g;
-    cartDims[0] = g.dims[0] = insp.gridSize()[0];
-    cartDims[1] = g.dims[1] = insp.gridSize()[1];
-    cartDims[2] = g.dims[2] = insp.gridSize()[2];
-
-    g.coord = &deck->getKeyword("COORD").getSIDoubleData()[0];
-    g.zcorn = &deck->getKeyword("ZCORN").getSIDoubleData()[0];
-
-    if (deck->hasKeyword("ACTNUM")) {
-        g.actnum = &deck->getKeyword("ACTNUM").getIntData()[0];
-        grid.processEclipseFormat(g, z_tol, false, false);
-    } else {
-        std::vector<int> dflt_actnum(g.dims[0] * g.dims[1] * g.dims[2], 1);
-
-        g.actnum = &dflt_actnum[0];
-        grid.processEclipseFormat(g, z_tol, false, false);
-    }
-}
-
-
 template<int dim, class RI>
 void assign_permeability(RI& r, int nc, double k)
 {
     typedef typename RI::SharedPermTensor Tensor;
+
     for (int c = 0; c < nc; ++c) {
         Tensor K = r.permeabilityModifiable(c);
         for (int i = 0; i < dim; ++i) {
@@ -163,17 +176,17 @@ void assign_permeability(RI& r, int nc, double k)
 template<int dim, class GI, class RI>
 void test_flowsolver(const GI& g, const RI& r)
 {
-    typedef typename GI::CellIterator                              CI;
-    typedef Opm::BasicBoundaryConditions<true, false>                  FBC;
-    typedef Opm::IncompFlowSolverHybrid<GI, RI, FBC,
-                                         Opm::MimeticIPAnisoRelpermEvaluator> FlowSolver;
+    typedef typename GI::CellIterator                 CI;
+    typedef Opm::BasicBoundaryConditions<true, false> FBC;
+
+    using FlowSolver =
+        Opm::IncompFlowSolverHybrid<GI, RI, FBC,
+                                    Opm::MimeticIPAnisoRelpermEvaluator>;
 
     FlowSolver solver;
 
     typedef Opm::FlowBC BC;
     FBC flow_bc(7);
-    //flow_bc.flowCond(1) = BC(BC::Dirichlet, 1.0*Opm::unit::barsa);
-    //flow_bc.flowCond(2) = BC(BC::Dirichlet, 0.0*Opm::unit::barsa);
     flow_bc.flowCond(5) = BC(BC::Dirichlet, 100.0*Opm::unit::barsa);
 
     typename CI::Vector gravity;
@@ -181,149 +194,47 @@ void test_flowsolver(const GI& g, const RI& r)
     gravity[2] = Opm::unit::gravity;
 
     solver.init(g, r, gravity, flow_bc);
-    // solver.printStats(std::cout);
-
-    //solver.assembleStatic(g, r);
-    //solver.printIP(std::cout);
 
     std::vector<double> src(g.numberOfCells(), 0.0);
     std::vector<double> sat(g.numberOfCells(), 0.0);
-#if 0
-    if (g.numberOfCells() > 1) {
-        src[0]     = 1.0;
-        src.back() = -1.0;
-    }
-#endif
 
     solver.solve(r, sat, flow_bc, src);
-
-#if 0
-    solver.printSystem("system");
-    typedef typename FlowSolver::SolutionType FlowSolution;
-    FlowSolution soln = solver.getSolution();
-    std::cout << "Cell Pressure:\n" << std::scientific << std::setprecision(15);
-    for (CI c = g.cellbegin(); c != g.cellend(); ++c) {
-        std::cout << '\t' << soln.pressure(c) << '\n';
-    }
-
-    std::cout << "Cell (Out) Fluxes:\n";
-    std::cout << "flux = [\n";
-    for (CI c = g.cellbegin(); c != g.cellend(); ++c) {
-        for (FI f = c->facebegin(); f != c->faceend(); ++f) {
-            std::cout << soln.outflux(f) << ' ';
-        }
-        std::cout << "\b\n";
-    }
-    std::cout << "]\n";
-#endif
 }
 
-
-using namespace Opm;
 
 int main(int argc, char** argv)
 try
 {
     Opm::parameter::ParameterGroup param(argc, argv);
-    Dune::MPIHelper::instance(argc,argv);
+    Dune::MPIHelper::instance(argc, argv);
+
+    auto parser = std::make_shared<Opm::Parser>();
+
+    Opm::DeckConstPtr
+        deck(parser->parseFile(param.get<std::string>("filename"),
+                               Opm::ParseContext()));
 
     // Make a grid
     Dune::CpGrid grid;
+    {
+        const auto z_tol = param.getDefault<double>("z_tolerance", 0.0);
 
-    Opm::ParseContext parseContext;
-    Opm::ParserPtr parser(new Opm::Parser());
-    Opm::DeckConstPtr deck(parser->parseFile(param.get<std::string>("filename") , parseContext));
-    double z_tol = param.getDefault<double>("z_tolerance", 0.0);
-    std::array<int,3> cartDims;
-    build_grid(deck, z_tol, grid, cartDims);
+        std::array<int,3> cartDims;
+        build_grid(deck, z_tol, grid, cartDims);
+    }
 
     // Make the grid interface
     Opm::GridInterfaceEuler<Dune::CpGrid> g(grid);
 
     // Reservoir properties.
-    typedef ReservoirPropertyCapillaryAnisotropicRelperm<3> RP;
-    RP res_prop;
+    auto res_prop = Opm::ReservoirPropertyCapillaryAnisotropicRelperm<3>{};
     res_prop.init(deck, grid.globalCell());
 
     assign_permeability<3>(res_prop, g.numberOfCells(), 0.1*Opm::unit::darcy);
+
     test_flowsolver<3>(g, res_prop);
-
-#if 0
-    // Make flow equation boundary conditions.
-    // Pressure 1.0e5 on the left, 0.0 on the right.
-    // Recall that the boundary ids range from 1 to 6 for the cartesian edges,
-    // and that boundary id 0 means interiour face/intersection.
-    typedef FlowBoundaryCondition BC;
-    FlowBoundaryConditions flow_bcond(7);
-    flow_bcond[1] = BC(BC::Dirichlet, 1.0e5);
-    flow_bcond[2] = BC(BC::Dirichlet, 0.0);
-
-    // Make transport equation boundary conditions.
-    // The default one is fine (sat = 1.0 on inflow).
-    SaturationBoundaryConditions sat_bcond(7);
-
-    // No injection or production.
-    SparseVector<double> injection_rates(g.numberOfCells());
-
-    // Make a solver.
-    typedef EulerUpstream<GridInterface,
-                          RP,
-                          SaturationBoundaryConditions> TransportSolver;
-    TransportSolver transport_solver(g, res_prop, sat_bcond, injection_rates);
-
-    // Define a flow field with constant velocity
-    Dune::FieldVector<double, 3> vel(0.0);
-    vel[0] = 2.0;
-    vel[1] = 1.0;
-    TestSolution<GridInterface> flow_solution(g, vel);
-    // Solve a step.
-    double time = 1.0;
-    std::vector<double> sat(g.numberOfCells(), 0.0);
-    Dune::FieldVector<double, 3> gravity(0.0);
-    gravity[2] = -9.81;
-    transport_solver.transportSolve(sat, time, gravity, flow_solution);
-#endif
 }
-catch (const std::exception &e) {
+catch (const std::exception& e) {
     std::cerr << "Program threw an exception: " << e.what() << "\n";
     throw;
 }
-
-
-
-#if 0
-int main (int argc , char **argv) try {
-    try {
-#if HAVE_MPI
-	// initialize MPI
-	MPI_Init(&argc,&argv);
-	// get own rank
-	int rank;
-	MPI_Comm_rank(MPI_COMM_WORLD,&rank);
-#endif
-	//check_yasp<3,0>();  // 3D, 1 x 1 x 1 cell
-	check_cpgrid<0>();
-	check_cpgrid<1>();
-	check_cpgrid<2>();
-
-    } catch (Dune::Exception &e) {
-	std::cerr << e << std::endl;
-	return 1;
-    } catch (...) {
-	std::cerr << "Generic exception!" << std::endl;
-	return 2;
-    }
-
-#if HAVE_MPI
-    // Terminate MPI
-    MPI_Finalize();
-#endif
-
-    return 0;
-}
-catch (const std::exception &e) {
-    std::cerr << "Program threw an exception: " << e.what() << "\n";
-    throw;
-}
-
-#endif

--- a/examples/mimetic_solver_test.cpp
+++ b/examples/mimetic_solver_test.cpp
@@ -35,37 +35,19 @@
 
 #include "config.h"
 
-#include <opm/porsol/common/SimulatorUtilities.hpp>
-#include <dune/grid/io/file/vtk/vtkwriter.hh>
-
-#include <dune/grid/CpGrid.hpp>
-#include <opm/porsol/common/fortran.hpp>
-#include <opm/porsol/common/blas_lapack.hpp>
-#include <opm/porsol/common/Matrix.hpp>
-#include <opm/porsol/common/GridInterfaceEuler.hpp>
-#include <opm/porsol/common/ReservoirPropertyCapillary.hpp>
-#include <opm/porsol/common/BoundaryConditions.hpp>
-#include <opm/porsol/common/setupGridAndProps.hpp>
-#include <opm/porsol/mimetic/MimeticIPEvaluator.hpp>
-#include <opm/porsol/mimetic/IncompFlowSolverHybrid.hpp>
-#include <opm/core/utility/parameters/ParameterGroup.hpp>
-#include <opm/core/utility/Units.hpp>
-
-#include <algorithm>
-#include <iostream>
-#include <iomanip>
-#include <array>
-
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
 
-#include <dune/grid/yaspgrid.hh>
-
 #include <dune/common/version.hh>
+
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
 #else
 #include <dune/common/mpihelper.hh>
 #endif
+
+#include <dune/grid/io/file/vtk/vtkwriter.hh>
+
+#include <dune/grid/yaspgrid.hh>
 
 #if HAVE_ALUGRID
 #include <dune/common/shared_ptr.hh>
@@ -77,7 +59,26 @@
 
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
+#include <opm/core/utility/parameters/ParameterGroup.hpp>
+#include <opm/core/utility/Units.hpp>
 
+#include <dune/grid/CpGrid.hpp>
+
+#include <opm/porsol/common/BoundaryConditions.hpp>
+#include <opm/porsol/common/GridInterfaceEuler.hpp>
+#include <opm/porsol/common/Matrix.hpp>
+#include <opm/porsol/common/ReservoirPropertyCapillary.hpp>
+#include <opm/porsol/common/SimulatorUtilities.hpp>
+#include <opm/porsol/common/blas_lapack.hpp>
+#include <opm/porsol/common/fortran.hpp>
+#include <opm/porsol/common/setupGridAndProps.hpp>
+#include <opm/porsol/mimetic/IncompFlowSolverHybrid.hpp>
+#include <opm/porsol/mimetic/MimeticIPEvaluator.hpp>
+
+#include <algorithm>
+#include <array>
+#include <iomanip>
+#include <iostream>
 
 #if USE_ALUGRID
 template<class GType>

--- a/examples/sim_blackoil_impes.cpp
+++ b/examples/sim_blackoil_impes.cpp
@@ -17,24 +17,12 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
-
 #include "config.h"
-
-#include <opm/porsol/blackoil/fluid/BlackoilPVT.hpp>
-#include <opm/porsol/blackoil/BlackoilFluid.hpp>
-#include <opm/porsol/blackoil/BlackoilSimulator.hpp>
-#include <opm/porsol/common/SimulatorUtilities.hpp>
-#include <dune/grid/CpGrid.hpp>
-#include <opm/porsol/common/Rock.hpp>
-#include <opm/porsol/mimetic/TpfaCompressible.hpp>
-#include <opm/core/utility/StopWatch.hpp>
-#include <opm/porsol/blackoil/BlackoilWells.hpp>
-#include <opm/porsol/blackoil/ComponentTransport.hpp>
 
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
+
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
 #else
@@ -42,6 +30,19 @@
 #endif
 
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/core/utility/StopWatch.hpp>
+
+#include <dune/grid/CpGrid.hpp>
+
+#include <opm/porsol/blackoil/BlackoilFluid.hpp>
+#include <opm/porsol/blackoil/BlackoilSimulator.hpp>
+#include <opm/porsol/blackoil/BlackoilWells.hpp>
+#include <opm/porsol/blackoil/ComponentTransport.hpp>
+#include <opm/porsol/blackoil/fluid/BlackoilPVT.hpp>
+#include <opm/porsol/common/Rock.hpp>
+#include <opm/porsol/common/SimulatorUtilities.hpp>
+#include <opm/porsol/mimetic/TpfaCompressible.hpp>
 
 #include <iostream>
 
@@ -55,7 +56,6 @@ typedef Opm::ExplicitCompositionalTransport<Grid, Rock, Fluid, Wells> TransportS
 
 
 typedef Opm::BlackoilSimulator<Grid, Rock, Fluid, Wells, FlowSolver, TransportSolver> Simulator;
-
 
 int main(int argc, char** argv)
 try
@@ -72,11 +72,10 @@ try
     clock.start();
     sim.simulate();
     clock.stop();
-    std::cout << "\n\nSimulation clock time (secs): " << clock.secsSinceStart() << std::endl;
+    std::cout << "\n\nSimulation clock time (secs): "
+              << clock.secsSinceStart() << std::endl;
 }
 catch (const std::exception &e) {
     std::cerr << "Program threw an exception: " << e.what() << "\n";
     throw;
 }
-
-

--- a/examples/sim_steadystate_explicit.cpp
+++ b/examples/sim_steadystate_explicit.cpp
@@ -18,22 +18,27 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "config.h"
 
 #define VERBOSE
 //#define USE_TBB
 
-#include "config.h"
-
-#include "SimulatorTester.hpp"
-#include "SimulatorTesterFlexibleBC.hpp"
-#include <opm/porsol/common/SimulatorTraits.hpp>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
+
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
 #else
 #include <dune/common/mpihelper.hh>
 #endif
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include "SimulatorTester.hpp"
+#include "SimulatorTesterFlexibleBC.hpp"
+
+#include <opm/porsol/common/SimulatorTraits.hpp>
 
 #ifdef USE_TBB
 #include <tbb/task_scheduler_init.h>
@@ -51,10 +56,12 @@ try
 {
     Opm::parameter::ParameterGroup param(argc, argv);
     Dune::MPIHelper::instance(argc,argv);
+
 #ifdef USE_TBB
     int num_threads = param.getDefault("num_threads", tbb::task_scheduler_init::default_num_threads());
     tbb::task_scheduler_init init(num_threads);
 #endif
+
     Simulator sim;
     sim.init(param);
     sim.run();

--- a/examples/sim_steadystate_implicit.cpp
+++ b/examples/sim_steadystate_implicit.cpp
@@ -17,14 +17,13 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
-
 #define VERBOSE
 
 #include "config.h"
 
 #include "SimulatorTester.hpp"
 #include "SimulatorTesterFlexibleBC.hpp"
+
 #include <opm/porsol/euler/EulerUpstreamImplicit.hpp>
 #include <opm/porsol/common/SimulatorTraits.hpp>
 
@@ -39,13 +38,12 @@ namespace Opm
         struct TransportSolver
         {
             //enum { Dimension = GridInterface::Dimension };
-        	enum { Dimension = GridInterface::Dimension };
+            enum { Dimension = GridInterface::Dimension };
             typedef typename IsotropyPolicy::template ResProp<Dimension>::Type RP;
 
             typedef EulerUpstreamImplicit<GridInterface,
-                                  RP,
-                                  BoundaryConditions> Type;
-
+                                          RP,
+                                          BoundaryConditions> Type;
         };
     };
 }
@@ -60,6 +58,7 @@ try
 {
     Opm::parameter::ParameterGroup param(argc, argv);
     Dune::MPIHelper::instance(argc,argv);
+
     Simulator sim;
     sim.init(param);
     sim.run();

--- a/examples/steadystate_test_implicit.cpp
+++ b/examples/steadystate_test_implicit.cpp
@@ -32,43 +32,49 @@
   You should have received a copy of the GNU General Public License
   along with OpenRS.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include <config.h>
 
-
-//#define VERBOSE
-#include <opm/upscaling/SteadyStateUpscalerImplicit.hpp>
-#include <opm/upscaling/SteadyStateUpscalerManagerImplicit.hpp>
-//#include <opm/upscaling/UpscalingTraits.hpp>
-#include <opm/porsol/euler/EulerUpstreamImplicit.hpp>
-#include <opm/porsol/common/SimulatorTraits.hpp>
-#include <iostream>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
+
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
 #else
 #include <dune/common/mpihelper.hh>
 #endif
 
-namespace Opm{
-	template <class IsotropyPolicy>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/porsol/common/SimulatorTraits.hpp>
+#include <opm/porsol/euler/EulerUpstreamImplicit.hpp>
+
+#include <opm/upscaling/SteadyStateUpscalerImplicit.hpp>
+#include <opm/upscaling/SteadyStateUpscalerManagerImplicit.hpp>
+
+#include <iostream>
+
+namespace Opm {
+    template <class IsotropyPolicy>
     struct Implicit
     {
         template <class GridInterface, class BoundaryConditions>
         struct TransportSolver
         {
-            //enum { Dimension = GridInterface::Dimension };
-        	enum { Dimension = GridInterface::Dimension };
+            enum { Dimension = GridInterface::Dimension };
             typedef typename IsotropyPolicy::template ResProp<Dimension>::Type RP;
 
             typedef EulerUpstreamImplicit<GridInterface,
-                                  RP,
-                                  BoundaryConditions> Type;
+                                          RP,
+                                          BoundaryConditions> Type;
 
         };
     };
-	typedef SimulatorTraits<Isotropic, Implicit> UpscalingTraitsBasicImplicit;
+
+    typedef SimulatorTraits<Isotropic, Implicit> UpscalingTraitsBasicImplicit;
 }
+
 using namespace Opm;
 
 int main(int argc, char** argv)
@@ -78,8 +84,10 @@ try
 
     // Initialize.
     Opm::parameter::ParameterGroup param(argc, argv);
+
     // MPIHelper::instance(argc,argv) ;
     typedef SteadyStateUpscalerImplicit<UpscalingTraitsBasicImplicit> upscaler_t;
+
     SteadyStateUpscalerManagerImplicit<upscaler_t> mgr;
     mgr.upscale(param);
 }
@@ -87,4 +95,3 @@ catch (const std::exception &e) {
     std::cerr << "Program threw an exception: " << e.what() << "\n";
     throw;
 }
-

--- a/examples/upscale_avg.cpp
+++ b/examples/upscale_avg.cpp
@@ -39,6 +39,25 @@
  */
 #include <config.h>
 
+#include <opm/parser/eclipse/Deck/DeckItem.hpp>
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
+#include <dune/common/parallel/mpihelper.hh>
+#else
+#include <dune/common/mpihelper.hh>
+#endif
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/output/eclipse/EclipseGridInspector.hpp>
+
+#include <opm/upscaling/ParserAdditions.hpp>
+#include <opm/upscaling/SinglePhaseUpscaler.hpp>
+
 #include <cmath>
 #include <cstdlib>
 #include <ctime>
@@ -48,34 +67,25 @@
 #include <memory>
 #include <numeric> // for std::accumulate
 #include <sstream>
+
 #include <sys/utsname.h>
-
-#include <opm/parser/eclipse/Deck/DeckItem.hpp>
-#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
-#include <opm/upscaling/ParserAdditions.hpp>
-#include <opm/upscaling/SinglePhaseUpscaler.hpp>
-#include <opm/output/eclipse/EclipseGridInspector.hpp>
-
-#include <dune/common/version.hh>
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
-#include <dune/common/parallel/mpihelper.hh>
-#else
-#include <dune/common/mpihelper.hh>
-#endif
 
 using namespace Opm;
 using namespace std;
 
-void usage() {
-    cout << endl <<
-        "Usage: upscale_avg <options> <eclipsefile>" << endl <<
-        "were the options are:" << endl <<
-        "-use_actnum                  -- If used and given a number larger than 0, the cells with" << endl <<
-        "                                ACTNUM 0 is removed from the calculations" << endl;
-}
-void usageandexit() {
-    usage();
-    exit(1);
+namespace {
+    void usage() {
+        cout << endl <<
+            "Usage: upscale_avg <options> <eclipsefile>" << endl <<
+            "were the options are:" << endl <<
+            "-use_actnum                  -- If used and given a number larger than 0, the cells with" << endl <<
+            "                                ACTNUM 0 is removed from the calculations" << endl;
+    }
+
+    void usageandexit() {
+        usage();
+        exit(EXIT_FAILURE);
+    }
 }
 
 

--- a/examples/upscale_avg.cpp
+++ b/examples/upscale_avg.cpp
@@ -39,9 +39,6 @@
  */
 #include <config.h>
 
-#include <opm/parser/eclipse/Deck/DeckItem.hpp>
-#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
-
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
@@ -55,7 +52,7 @@
 
 #include <opm/output/eclipse/EclipseGridInspector.hpp>
 
-#include <opm/upscaling/ParserAdditions.hpp>
+#include <opm/upscaling/RelPermUtils.hpp>
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
 
 #include <cmath>
@@ -171,10 +168,7 @@ int main(int varnum, char** vararg) try {
     // eclParser_p is here a pointer to an object of type Opm::EclipseGridParser
     // (this pointer trick is necessary for the try-catch-clause to work)
     
-   Opm::ParseContext parseMode;
-   auto parser = std::make_shared<Opm::Parser>();
-   Opm::addNonStandardUpscalingKeywords(*parser);
-   Opm::DeckConstPtr deck(parser->parseFile(ECLIPSEFILENAME , parseMode));
+    auto deck = RelPermUpscaleHelper::parseEclipseFile(ECLIPSEFILENAME);
 
     Opm::EclipseGridInspector eclInspector(deck);
 

--- a/examples/upscale_avg.cpp
+++ b/examples/upscale_avg.cpp
@@ -162,8 +162,8 @@ int main(int varnum, char** vararg) try {
     // (this pointer trick is necessary for the try-catch-clause to work)
     
    Opm::ParseContext parseMode;
-   Opm::ParserPtr parser(new Opm::Parser());
-   Opm::addNonStandardUpscalingKeywords(parser);
+   auto parser = std::make_shared<Opm::Parser>();
+   Opm::addNonStandardUpscalingKeywords(*parser);
    Opm::DeckConstPtr deck(parser->parseFile(ECLIPSEFILENAME , parseMode));
 
     Opm::EclipseGridInspector eclInspector(deck);

--- a/examples/upscale_avg.cpp
+++ b/examples/upscale_avg.cpp
@@ -1,4 +1,3 @@
-
 /*
   Copyright 2010 Statoil ASA.
 
@@ -40,14 +39,15 @@
  */
 #include <config.h>
 
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <iomanip>
-#include <ctime>
 #include <cmath>
 #include <cstdlib>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <memory>
 #include <numeric> // for std::accumulate
+#include <sstream>
 #include <sys/utsname.h>
 
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>

--- a/examples/upscale_cap.cpp
+++ b/examples/upscale_cap.cpp
@@ -54,14 +54,16 @@
  */
 #include <config.h>
 
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <iomanip>
-#include <ctime>
-#include <cmath>
 #include <cfloat> // for DB_MAX/DBL_MIN
+#include <cmath>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
 #include <map>
+#include <memory>
+#include <sstream>
+
 #include <sys/utsname.h>
 
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>

--- a/examples/upscale_cap.cpp
+++ b/examples/upscale_cap.cpp
@@ -54,9 +54,6 @@
  */
 #include <config.h>
 
-#include <opm/parser/eclipse/Deck/DeckItem.hpp>
-#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
-
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
@@ -71,8 +68,8 @@
 #include <opm/core/utility/MonotCubicInterpolator.hpp>
 #include <opm/core/utility/Units.hpp>
 
+#include <opm/upscaling/RelPermUtils.hpp>
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
-#include <opm/upscaling/ParserAdditions.hpp>
 
 #include <cfloat> // for DB_MAX/DBL_MIN
 #include <cmath>
@@ -241,10 +238,7 @@ try
    eclipsefile.close(); 
 
    cout << "Parsing Eclipse file <" << ECLIPSEFILENAME << "> ... " << endl;
-   Opm::ParseContext parseMode;
-   auto parser = std::make_shared<Opm::Parser>();
-   Opm::addNonStandardUpscalingKeywords(*parser);
-   Opm::DeckConstPtr deck(parser->parseFile(ECLIPSEFILENAME , parseMode));
+   auto deck = RelPermUpscaleHelper::parseEclipseFile(ECLIPSEFILENAME);
    
    // Check that we have the information we need from the eclipse file:  
    if (! (deck->hasKeyword("SPECGRID") && deck->hasKeyword("COORD") && deck->hasKeyword("ZCORN")  

--- a/examples/upscale_cap.cpp
+++ b/examples/upscale_cap.cpp
@@ -234,8 +234,8 @@ try
 
    cout << "Parsing Eclipse file <" << ECLIPSEFILENAME << "> ... " << endl;
    Opm::ParseContext parseMode;
-   Opm::ParserPtr parser(new Opm::Parser());
-   Opm::addNonStandardUpscalingKeywords(parser);
+   auto parser = std::make_shared<Opm::Parser>();
+   Opm::addNonStandardUpscalingKeywords(*parser);
    Opm::DeckConstPtr deck(parser->parseFile(ECLIPSEFILENAME , parseMode));
    
    // Check that we have the information we need from the eclipse file:  

--- a/examples/upscale_cond.cpp
+++ b/examples/upscale_cond.cpp
@@ -347,8 +347,8 @@ try
    if (isMaster) cout << "Parsing Eclipse file <" << ECLIPSEFILENAME << "> ... ";
    flush(cout);   start = clock();
    Opm::ParseContext parseMode;
-   Opm::ParserPtr parser(new Opm::Parser());
-   Opm::addNonStandardUpscalingKeywords(parser);
+   auto parser = std::make_shared<Opm::Parser>();
+   Opm::addNonStandardUpscalingKeywords(*parser);
    Opm::DeckConstPtr deck(parser->parseFile(ECLIPSEFILENAME , parseMode));
 
    finish = clock();   timeused = (double(finish)-double(start))/CLOCKS_PER_SEC;

--- a/examples/upscale_cond.cpp
+++ b/examples/upscale_cond.cpp
@@ -51,14 +51,16 @@
  */
 #include <config.h>
 
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <iomanip>
-#include <ctime>
-#include <cmath>
 #include <cfloat> // for DBL_MAX
+#include <cmath>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
 #include <map>
+#include <memory>
+#include <sstream>
+
 #include <sys/utsname.h>
 
 #include <opm/common/utility/platform_dependent/disable_warnings.h>

--- a/examples/upscale_elasticity.cpp
+++ b/examples/upscale_elasticity.cpp
@@ -13,7 +13,6 @@
 # include "config.h"     
 #endif
 
-
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/exceptions.hh> // We use exceptions
@@ -35,14 +34,16 @@
 
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
-#include <opm/elasticity/elasticity_upscale.hpp>
-#include <opm/elasticity/matrixops.hpp>
 #include <opm/core/utility/StopWatch.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 
-#include <iostream>
-#include <unistd.h>
+#include <opm/elasticity/elasticity_upscale.hpp>
+#include <opm/elasticity/matrixops.hpp>
+
 #include <cstring>
+#include <iostream>
+
+#include <unistd.h>
 
 using namespace Opm::Elasticity;
 

--- a/examples/upscale_perm.cpp
+++ b/examples/upscale_perm.cpp
@@ -45,28 +45,33 @@
  */
 #include <config.h>
 
-#include <ctime>
-#include <fstream>
-#include <iomanip>
-#include <ctime>
-#include <iostream>
-#include <memory>
-#include <sstream>
-
-#include <sys/utsname.h>
-
-#include <opm/upscaling/SinglePhaseUpscaler.hpp>
-#include <opm/upscaling/ParserAdditions.hpp>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
+
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
 #else
 #include <dune/common/mpihelper.hh>
 #endif
 
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/upscaling/SinglePhaseUpscaler.hpp>
+#include <opm/upscaling/ParserAdditions.hpp>
+
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <sstream>
+
+#include <sys/utsname.h>
+
 using namespace std;
 
+namespace {
 
 void usage() {
     cout << endl <<
@@ -381,6 +386,8 @@ int upscale(int varnum, char** vararg) {
     }
     return 0;   
 }
+
+} // namespace anonymous
 
 /**
    @brief Upscales permeability

--- a/examples/upscale_perm.cpp
+++ b/examples/upscale_perm.cpp
@@ -45,11 +45,13 @@
  */
 #include <config.h>
 
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <iomanip>
 #include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <sstream>
+
 #include <sys/utsname.h>
 
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>

--- a/examples/upscale_perm.cpp
+++ b/examples/upscale_perm.cpp
@@ -57,8 +57,8 @@
 
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
+#include <opm/upscaling/RelPermUtils.hpp>
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
-#include <opm/upscaling/ParserAdditions.hpp>
 
 #include <ctime>
 #include <fstream>
@@ -200,10 +200,7 @@ int upscale(int varnum, char** vararg) {
     cout << "Parsing Eclipse file <" << ECLIPSEFILENAME << "> ... ";
     flush(cout);   start = clock();
 
-    Opm::ParseContext parseMode;
-    auto parser = std::make_shared<Opm::Parser>();
-    Opm::addNonStandardUpscalingKeywords(*parser);
-    Opm::DeckConstPtr deck(parser->parseFile(ECLIPSEFILENAME , parseMode));
+    auto deck = Opm::RelPermUpscaleHelper::parseEclipseFile(ECLIPSEFILENAME);
 
     finish = clock();   timeused = (double(finish)-double(start))/CLOCKS_PER_SEC;
     cout << " (" << timeused <<" secs)" << endl;

--- a/examples/upscale_perm.cpp
+++ b/examples/upscale_perm.cpp
@@ -48,6 +48,7 @@
 #include <ctime>
 #include <fstream>
 #include <iomanip>
+#include <ctime>
 #include <iostream>
 #include <memory>
 #include <sstream>
@@ -195,8 +196,8 @@ int upscale(int varnum, char** vararg) {
     flush(cout);   start = clock();
 
     Opm::ParseContext parseMode;
-    Opm::ParserPtr parser(new Opm::Parser());
-    Opm::addNonStandardUpscalingKeywords(parser);
+    auto parser = std::make_shared<Opm::Parser>();
+    Opm::addNonStandardUpscalingKeywords(*parser);
     Opm::DeckConstPtr deck(parser->parseFile(ECLIPSEFILENAME , parseMode));
 
     finish = clock();   timeused = (double(finish)-double(start))/CLOCKS_PER_SEC;

--- a/examples/upscale_relperm.cpp
+++ b/examples/upscale_relperm.cpp
@@ -333,21 +333,6 @@ namespace {
         return parser->parseFile(ECLIPSEFILENAME, Opm::ParseContext{});
     }
 
-    std::array<int, 3>
-    getCartesianDimension(const std::shared_ptr<const Opm::Deck>& deck)
-    {
-        const auto grid = Opm::EclipseGrid(deck);
-
-        return
-        {
-            {
-                static_cast<int>(grid.getNX()),
-                static_cast<int>(grid.getNY()),
-                static_cast<int>(grid.getNZ()),
-            }
-        };
-    }
-
     void invertCapillaryPressureIsotropic(const char*                ROCKFILENAME,
                                           const int                  i,
                                           const int                  jFunctionCurve,
@@ -579,8 +564,7 @@ try
    // Test if filename exists and is readable
    start = clock();
 
-   auto       deck = parseEclipseFile(ECLIPSEFILENAME, helper.isMaster);
-   const auto res  = getCartesianDimension(deck);
+   auto deck = parseEclipseFile(ECLIPSEFILENAME, helper.isMaster);
 
    finish   = clock();
    timeused = (double(finish) - double(start)) / CLOCKS_PER_SEC;
@@ -688,7 +672,7 @@ try
 
    /* If gravity is to be included, calculate z-values of every cell: */
    if (includeGravity) {
-       helper.calculateCellPressureGradients(res);
+       helper.calculateCellPressureGradients();
    }
 
    /******************************************************************************

--- a/examples/upscale_relperm.cpp
+++ b/examples/upscale_relperm.cpp
@@ -58,9 +58,6 @@
  */
 #include <config.h>
 
-#include <opm/parser/eclipse/Deck/DeckItem.hpp>
-#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
-
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
@@ -75,7 +72,6 @@
 
 #include <opm/core/utility/Units.hpp>
 
-#include <opm/upscaling/ParserAdditions.hpp>
 #include <opm/upscaling/RelPermUtils.hpp>
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
 
@@ -304,33 +300,6 @@ namespace {
             {"doEclipseCheck",             "true"}, // Check if minimum relpermvalues in input are zero (specify critical saturations)
             {"critRelpermThresh",          "1e-6"}, // Threshold for setting minimum relperm to 0 (thus specify critical saturations)
         };
-    }
-
-    template <class String>
-    std::shared_ptr<const Opm::Deck>
-    parseEclipseFile(const String& ECLIPSEFILENAME, const bool isMaster)
-    {
-        {
-            ifstream eclipsefile(ECLIPSEFILENAME, std::ios::in);
-            if (!eclipsefile) {
-                std::stringstream str;
-                str << "Error: Filename " << ECLIPSEFILENAME
-                    << " not found or not readable.";
-
-                throw std::domain_error(str.str());
-            }
-        }
-
-        if (isMaster) {
-            std::cout << "Parsing Eclipse file <" << ECLIPSEFILENAME << "> ... ";
-        }
-
-        flush(std::cout);
-
-        auto parser = std::make_shared<Opm::Parser>();
-        Opm::addNonStandardUpscalingKeywords(*parser);
-
-        return parser->parseFile(ECLIPSEFILENAME, Opm::ParseContext{});
     }
 
     void invertCapillaryPressureIsotropic(const char*                ROCKFILENAME,
@@ -564,7 +533,7 @@ try
    // Test if filename exists and is readable
    start = clock();
 
-   auto deck = parseEclipseFile(ECLIPSEFILENAME, helper.isMaster);
+   auto deck = RelPermUpscaleHelper::parseEclipseFile(ECLIPSEFILENAME);
 
    finish   = clock();
    timeused = (double(finish) - double(start)) / CLOCKS_PER_SEC;

--- a/examples/upscale_relperm.cpp
+++ b/examples/upscale_relperm.cpp
@@ -67,7 +67,6 @@
 #include <map>
 #include <memory>
 #include <sstream>
-
 #include <sys/utsname.h>
 
 #include <opm/common/utility/platform_dependent/disable_warnings.h>
@@ -391,8 +390,8 @@ try
    if (helper.isMaster) cout << "Parsing Eclipse file <" << ECLIPSEFILENAME << "> ... ";
    flush(cout);   start = clock();
    Opm::ParseContext parseMode;
-   Opm::ParserPtr parser(new Opm::Parser());
-   Opm::addNonStandardUpscalingKeywords(parser);
+   auto parser = std::make_shared<Opm::Parser>();
+   Opm::addNonStandardUpscalingKeywords(*parser);
    Opm::DeckConstPtr deck(parser->parseFile(ECLIPSEFILENAME , parseMode));
    finish = clock();   timeused = (double(finish)-double(start))/CLOCKS_PER_SEC;
    if (helper.isMaster) cout << " (" << timeused <<" secs)" << endl;

--- a/examples/upscale_relperm.cpp
+++ b/examples/upscale_relperm.cpp
@@ -21,13 +21,13 @@
    @file upscale_relperm.C
    @brief Upscales relative permeability as a fuction of water saturation assuming capillary equilibrium.
 
-   Description: 
- 
+   Description:
+
    Reads in a lithofacies geometry in Eclipse format, reads in J(S_w)
    and relpermcurve(S_w) for each stone type, and calculates upscaled
    (three directions) relative permeability curves as a function of Sw.
-  
-   The relative permeability computation is based on 
+
+   The relative permeability computation is based on
      - Capillary equilibrium, p_c is spatially invariant.
      - Optional gravitational effects. If gravity is not specified,
        gravity will be assumed to be zero.
@@ -41,23 +41,45 @@
      - Outputted capillary pressure is in Pascals.
 
    Steps in the code:
-  
+
    1: Process command line options.
-   2: Read Eclipse file 
+   2: Read Eclipse file
    3: Read relperm- and J-function for each stone-type.
    4: Tesselate the grid (Sintef code)
-   5: Find minimum and maximum capillary pressure from the 
+   5: Find minimum and maximum capillary pressure from the
       J-functions in each cell.
    6: Upscale water saturation as a function of capillary pressure
    7: Upscale single phase permeability.
    8: Upscale phase permeability for capillary pressures
-      that corresponds to a uniform saturation grid, and 
+      that corresponds to a uniform saturation grid, and
       compute relative permeability.
    9: Print output to screen and optionally to file.
 
  */
 #include <config.h>
 
+#include <opm/parser/eclipse/Deck/DeckItem.hpp>
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
+#include <dune/common/version.hh>
+
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
+#include <dune/common/parallel/mpihelper.hh>
+#else
+#include <dune/common/mpihelper.hh>
+#endif
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/core/utility/Units.hpp>
+
+#include <opm/upscaling/ParserAdditions.hpp>
+#include <opm/upscaling/RelPermUtils.hpp>
+#include <opm/upscaling/SinglePhaseUpscaler.hpp>
+
+#include <algorithm>
 #include <cfloat> // for DBL_MAX/DBL_MIN
 #include <cmath>
 #include <ctime>
@@ -67,25 +89,10 @@
 #include <map>
 #include <memory>
 #include <sstream>
+#include <stdexcept>
+#include <utility>
+
 #include <sys/utsname.h>
-
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
-
-#include <dune/common/version.hh>
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
-#include <dune/common/parallel/mpihelper.hh>
-#else
-#include <dune/common/mpihelper.hh>
-#endif
-
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
-
-#include <opm/parser/eclipse/Deck/DeckItem.hpp>
-#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
-#include <opm/core/utility/Units.hpp>
-#include <opm/upscaling/SinglePhaseUpscaler.hpp>
-#include <opm/upscaling/ParserAdditions.hpp>
-#include <opm/upscaling/RelPermUtils.hpp>
 
 using namespace Opm;
 using namespace std;
@@ -95,16 +102,16 @@ static void usage()
 {
     cerr << "Usage: upscale_relperm <options> <eclipsefile> stoneA.txt stoneB.txt ..." << endl <<
         "where the options are:" << endl <<
-        "  -bc <string>                 -- which boundary conditions to use." << endl << 
-        "                                  Possible values are f (fixed), l (linear)" << endl << 
-        "                                  and p (periodic). Default f (fixed)." << endl << 
+        "  -bc <string>                 -- which boundary conditions to use." << endl <<
+        "                                  Possible values are f (fixed), l (linear)" << endl <<
+        "                                  and p (periodic). Default f (fixed)." << endl <<
         "  -points <integer>            -- Number of saturation points to upscale for." << endl <<
         "                                  Uniformly distributed within saturation endpoints." << endl <<
-        "                                  Default 30." << endl << 
+        "                                  Default 30." << endl <<
         "  -relPermCurve <integer>      -- For isotropic input, the column number in the stone-files" << endl <<
-        "                                  that represents the phase to be upscaled," << endl << 
+        "                                  that represents the phase to be upscaled," << endl <<
         "                                  typically 2 (default) for water and 3 for oil." << endl <<
-        "  -jFunctionCurve <integer>    -- the column number in the stone-files that" << endl << 
+        "  -jFunctionCurve <integer>    -- the column number in the stone-files that" << endl <<
         "                                  represent the Leverett J-function. Default 4." << endl <<
         "  -upscaleBothPhases <bool>    -- If this is true, relperm for both phases will be upscaled" << endl <<
         "                                  and both will be outputted to Eclipse format. Default true." << endl <<
@@ -112,10 +119,10 @@ static void usage()
         "                                  for anisotropic input, relPermCurves are assumed to be 3-5" << endl <<
         "                                  and 6-8 respectively for the two phases" << endl <<
         "  -gravity <float>             -- use 9.81 for standard gravity. Default zero. Unit m/s^2." << endl <<
-        "  -surfaceTension <float>      -- Surface tension to use in J-function/Pc conversion." << endl << 
-        "                                  Default 11 dynes/cm (oil-water systems). In absence of" << endl <<  
-        "                                  a correct value, the surface tension for gas-oil systems " << endl << 
-        "                                  could be 22.5 dynes/cm." << endl << 
+        "  -surfaceTension <float>      -- Surface tension to use in J-function/Pc conversion." << endl <<
+        "                                  Default 11 dynes/cm (oil-water systems). In absence of" << endl <<
+        "                                  a correct value, the surface tension for gas-oil systems " << endl <<
+        "                                  could be 22.5 dynes/cm." << endl <<
         "  -waterDensity <float>        -- density of water, only applicable to non-zero" << endl <<
         "                                  gravity, g/cm³. Default 1" << endl <<
         "  -oilDensity <float>          -- density of oil, only applicable to non-zero" << endl <<
@@ -129,9 +136,9 @@ static void usage()
         "                                  points. Suggested value: 1000." << endl <<
         "  -maxPermContrast <float>     -- maximal permeability contrast in model." << endl <<
         "                                  Default 10^7" << endl <<
-        "  -minPerm <float>             -- Minimum floating point value allowed for" << endl << 
-        "                                  phase permeability in computations. If set to zero," << endl << 
-        "                                  some models can end up singular. Default 10^-12" << endl << 
+        "  -minPerm <float>             -- Minimum floating point value allowed for" << endl <<
+        "                                  phase permeability in computations. If set to zero," << endl <<
+        "                                  some models can end up singular. Default 10^-12" << endl <<
         "  -maxPerm <float>             -- Maximum floating point value allowed for" << endl <<
         "                                  permeability. " << endl <<
         "                                  Default 100000. Unit Millidarcy." << endl <<
@@ -260,6 +267,230 @@ static void writeEclipseOutput(Lazy& RelPermValues,
     file.close();
 }
 
+namespace {
+    std::map<std::string, std::string> defineOptions()
+    {
+        return
+        {
+            {"bc",                            "f"}, // Fixed boundary conditions
+            {"points",                       "30"}, // Number of saturation points (uniformly distributed within saturation endpoints)
+            {"relPermCurve",                  "2"}, // Which column in the rock types are upscaled
+            {"upscaleBothPhases",          "true"}, // Whether to upscale for both phases in the same run. Default true.
+            {"jFunctionCurve",                "4"}, // Which column in the rock type file is the J-function curve
+            {"surfaceTension",               "11"}, // Surface tension given in dynes/cm
+            {"output",                         ""}, // If this is set, output goes to screen and to this file.
+            {"gravity",                     "0.0"}, // default is no gravitational effects
+            {"waterDensity",                "1.0"}, // default density of water, only applicable to gravity
+            {"oilDensity",                  "0.6"}, // ditto
+            {"interpolate",                   "0"}, // default is not to interpolate
+            {"maxpoints",                  "1000"}, // maximal number of saturation points.
+            {"outputprecision",               "4"}, // number of significant numbers to print
+            {"maxPermContrast",             "1e7"}, // maximum allowed contrast in each single-phase computation
+            {"minPerm",                   "1e-12"}, // absolute minimum for allowed cell permeability
+            {"maxPerm",                  "100000"}, // maximal allowed cell permeability
+            {"minPoro",                  "0.0001"}, // this limit is necessary for pcmin/max computation
+            {"saturationThreshold",     "0.00001"}, // accuracy threshold for saturation, we ignore Pc values that
+                                                    // give so small contributions near endpoints.
+            {"linsolver_tolerance",       "1e-12"}, // residual tolerance for linear solver
+            {"linsolver_verbosity",           "0"}, // verbosity level for linear solver
+            {"linsolver_max_iterations",      "0"}, // Maximum number of iterations allow, specify 0 for default
+            {"linsolver_type",                "3"}, // Type of linear solver: 0 = ILU0/CG, 1 = AMG/CG, 2 KAMG/CG, 3 FAST_AMG/CG
+            {"linsolver_prolongate_factor", "1.0"}, // Prolongation factor in AMG
+            {"linsolver_smooth_steps",        "1"}, // Number of smoothing steps in AMG
+            {"fluids",                       "ow"}, // Whether upscaling for oil/water (ow) or gas/oil (go)
+            {"krowxswirr",                   "-1"}, // Relative permeability in x direction of oil in corresponding oil/water system
+            {"krowyswirr",                   "-1"}, // Relative permeability in y direction of oil in corresponding oil/water system
+            {"krowzswirr",                   "-1"}, // Relative permeability in z direction of oil in corresponding oil/water system
+            {"doEclipseCheck",             "true"}, // Check if minimum relpermvalues in input are zero (specify critical saturations)
+            {"critRelpermThresh",          "1e-6"}, // Threshold for setting minimum relperm to 0 (thus specify critical saturations)
+        };
+    }
+
+    template <class String>
+    std::shared_ptr<const Opm::Deck>
+    parseEclipseFile(const String& ECLIPSEFILENAME, const bool isMaster)
+    {
+        {
+            ifstream eclipsefile(ECLIPSEFILENAME, std::ios::in);
+            if (!eclipsefile) {
+                std::stringstream str;
+                str << "Error: Filename " << ECLIPSEFILENAME
+                    << " not found or not readable.";
+
+                throw std::domain_error(str.str());
+            }
+        }
+
+        if (isMaster) {
+            std::cout << "Parsing Eclipse file <" << ECLIPSEFILENAME << "> ... ";
+        }
+
+        flush(std::cout);
+
+        auto parser = std::make_shared<Opm::Parser>();
+        Opm::addNonStandardUpscalingKeywords(*parser);
+
+        return parser->parseFile(ECLIPSEFILENAME, Opm::ParseContext{});
+    }
+
+    std::array<int, 3>
+    getCartesianDimension(const std::shared_ptr<const Opm::Deck>& deck)
+    {
+        const auto grid = Opm::EclipseGrid(deck);
+
+        return
+        {
+            {
+                static_cast<int>(grid.getNX()),
+                static_cast<int>(grid.getNY()),
+                static_cast<int>(grid.getNZ()),
+            }
+        };
+    }
+
+    void invertCapillaryPressureIsotropic(const char*                ROCKFILENAME,
+                                          const int                  i,
+                                          const int                  jFunctionCurve,
+                                          const int                  relPermCurve,
+                                          std::vector<std::string>&  JfunctionNames,
+                                          Opm::RelPermUpscaleHelper& helper)
+    {
+        MonotCubicInterpolator Jtmp;
+
+        try {
+            Jtmp = MonotCubicInterpolator(ROCKFILENAME, 1, jFunctionCurve);
+        }
+        catch (const char* errormessage) {
+            std::stringstream str;
+
+            str << "Error: " << errormessage << endl
+                << "Check filename and -jFunctionCurve" << endl;
+
+            throw std::runtime_error(str.str());
+        }
+
+        // Invert J-function, now we get saturation as a function of pressure:
+        if (Jtmp.isStrictlyMonotone()) {
+            helper.InvJfunctions.emplace_back(Jtmp.get_fVector(),
+                                              Jtmp.get_xVector());
+
+            JfunctionNames.push_back(ROCKFILENAME);
+
+            auto& krfunc = helper.Krfunctions[0];
+
+            if (helper.upscaleBothPhases) {
+                krfunc[0].emplace_back(ROCKFILENAME, 1, 2);
+                krfunc[1].emplace_back(ROCKFILENAME, 1, 3);
+            }
+            else {
+                krfunc[0].emplace_back(ROCKFILENAME, 1, relPermCurve);
+            }
+        }
+        else {
+            std::stringstream str;
+
+            str << "Error: Jfunction " << (i + 1)
+                << " in rock file "    << ROCKFILENAME
+                << " was not invertible.";
+
+            throw std::runtime_error(str.str());
+        }
+    }
+
+    void invertCapillaryPressureAnIsotropic(const char*                ROCKFILENAME,
+                                            const int                  i,
+                                            const int                  /* jFunctionCurve */,
+                                            const int                  /* relPermCurve */,
+                                            std::vector<std::string>&  JfunctionNames,
+                                            Opm::RelPermUpscaleHelper& helper)
+    {
+        MonotCubicInterpolator Pctmp;
+
+        try {
+            Pctmp = MonotCubicInterpolator(ROCKFILENAME, 2, 1);
+        }
+        catch (const char* errormessage) {
+            std::stringstream str;
+
+            str << "Error: " << errormessage << '\n'
+                << "Check filename and columns 1 and 2 (Pc and "
+                << helper.saturationstring << ')';
+
+            throw std::domain_error(str.str());
+        }
+
+        // Invert Pc(Sw) curve into Sw(Pc):
+        if (Pctmp.isStrictlyMonotone()) {
+            helper.SwPcfunctions.emplace_back(Pctmp.get_fVector(),
+                                              Pctmp.get_xVector());
+
+            JfunctionNames.push_back(ROCKFILENAME);
+
+            auto& krfunc = helper.Krfunctions;
+
+            krfunc[0][0].emplace_back(ROCKFILENAME, 2, 3);
+            krfunc[1][0].emplace_back(ROCKFILENAME, 2, 4);
+            krfunc[2][0].emplace_back(ROCKFILENAME, 2, 5);
+
+            if (helper.upscaleBothPhases) {
+                krfunc[0][1].emplace_back(ROCKFILENAME, 2, 6);
+                krfunc[1][1].emplace_back(ROCKFILENAME, 2, 7);
+                krfunc[2][1].emplace_back(ROCKFILENAME, 2, 8);
+            }
+        }
+        else {
+            std::stringstream str;
+
+            str << "Error: Pc(" << helper.saturationstring << ") curve "
+                << (i + 1) << " in rock file "
+                << ROCKFILENAME << " was not invertible.";
+
+            throw std::runtime_error(str.str());
+        }
+    }
+
+    void extractSaturationFunctions(const int                  varnum,
+                                    char*                      vararg[],
+                                    const int                  rockfileindex,
+                                    const int                  stone_types,
+                                    const int                  jFunctionCurve,
+                                    const int                  relPermCurve,
+                                    std::vector<std::string>&  JfunctionNames,
+                                    Opm::RelPermUpscaleHelper& helper)
+    {
+        // If input is anisotropic, then we are in second mode with
+        // different input file format
+
+        auto invertPc = helper.anisotropic_input
+            ? invertCapillaryPressureAnIsotropic
+            : invertCapillaryPressureIsotropic;
+
+        for (int i = 0 ; i < stone_types; ++i) {
+            const char* ROCKFILENAME =
+                vararg[(rockfileindex + stone_types == varnum)
+                       ? rockfileindex + i
+                       : rockfileindex];
+
+            // Check if rock file exists and is readable:
+            {
+                std::ifstream rockfile(ROCKFILENAME, std::ios::in);
+
+                if (!rockfile) {
+                    std::stringstream str;
+
+                    str << "Error: Filename " << ROCKFILENAME
+                        << " not found or not readable.";
+
+                    throw std::runtime_error(str.str());
+                }
+            }
+
+            invertPc(ROCKFILENAME, i, jFunctionCurve,
+                     relPermCurve, JfunctionNames, helper);
+        }
+    }
+}
+
 int main(int varnum, char** vararg)
 try
 {
@@ -287,38 +518,7 @@ try
    /*
      Populate options-map with default values
    */
-   map<string,string> options =
-       {{"bc",                            "f"}, // Fixed boundary conditions
-        {"points",                       "30"}, // Number of saturation points (uniformly distributed within saturation endpoints)
-        {"relPermCurve",                  "2"}, // Which column in the rock types are upscaled
-        {"upscaleBothPhases",          "true"}, // Whether to upscale for both phases in the same run. Default true.
-        {"jFunctionCurve",                "4"}, // Which column in the rock type file is the J-function curve
-        {"surfaceTension",               "11"}, // Surface tension given in dynes/cm
-        {"output",                         ""}, // If this is set, output goes to screen and to this file.
-        {"gravity",                     "0.0"}, // default is no gravitational effects
-        {"waterDensity",                "1.0"}, // default density of water, only applicable to gravity
-        {"oilDensity",                  "0.6"}, // ditto
-        {"interpolate",                   "0"}, // default is not to interpolate
-        {"maxpoints",                  "1000"}, // maximal number of saturation points.
-        {"outputprecision",               "4"}, // number of significant numbers to print
-        {"maxPermContrast",             "1e7"}, // maximum allowed contrast in each single-phase computation
-        {"minPerm",                   "1e-12"}, // absolute minimum for allowed cell permeability
-        {"maxPerm",                  "100000"}, // maximal allowed cell permeability
-        {"minPoro",                  "0.0001"}, // this limit is necessary for pcmin/max computation
-        {"saturationThreshold",     "0.00001"}, // accuracy threshold for saturation, we ignore Pc values that
-                                                // give so small contributions near endpoints.
-        {"linsolver_tolerance",       "1e-12"}, // residual tolerance for linear solver
-        {"linsolver_verbosity",           "0"}, // verbosity level for linear solver
-        {"linsolver_max_iterations",      "0"}, // Maximum number of iterations allow, specify 0 for default
-        {"linsolver_type",                "3"}, // Type of linear solver: 0 = ILU0/CG, 1 = AMG/CG, 2 KAMG/CG, 3 FAST_AMG/CG
-        {"linsolver_prolongate_factor", "1.0"}, // Prolongation factor in AMG
-        {"linsolver_smooth_steps",        "1"}, // Number of smoothing steps in AMG
-        {"fluids",                       "ow"}, // Whether upscaling for oil/water (ow) or gas/oil (go)
-        {"krowxswirr",                   "-1"}, // Relative permeability in x direction of oil in corresponding oil/water system
-        {"krowyswirr",                   "-1"}, // Relative permeability in y direction of oil in corresponding oil/water system
-        {"krowzswirr",                   "-1"}, // Relative permeability in z direction of oil in corresponding oil/water system
-        {"doEclipseCheck",             "true"}, // Check if minimum relpermvalues in input are zero (specify critical saturations)
-        {"critRelpermThresh",          "1e-6"}};// Threshold for setting minimum relperm to 0 (thus specify critical saturations)
+   auto options = defineOptions();
 
    /* Check first if there is anything on the command line to look for */
    if (varnum == 1) {
@@ -338,7 +538,7 @@ try
    }
 
    RelPermUpscaleHelper helper(mpi_rank, options);
-   bool owsystem = helper.saturationstring == "Sw";
+   const auto owsystem = helper.saturationstring == "Sw";
 
    // argeclindex should now point to the eclipse file
    static char* ECLIPSEFILENAME(vararg[argeclindex]);
@@ -347,13 +547,13 @@ try
    // argeclindex now points to the first J-function. This index is not
    // to be touched now.
    static int rockfileindex = argeclindex;
-   
+
 
    /* Check if at least one J-function is supplied on command line */
    if (varnum <= rockfileindex)
         throw std::runtime_error("Error: No J-functions found on command line.");
-    
-   /* Check validity of boundary conditions chosen, and make booleans 
+
+   /* Check validity of boundary conditions chosen, and make booleans
       for boundary conditions, this allows more readable code later. */
    helper.setupBoundaryConditions();
 
@@ -364,55 +564,43 @@ try
    // If this number is 1 or higher, the output will be interpolated, if not
    // the computed data is untouched.
    const int interpolationPoints = atoi(options["interpolate"].c_str());
-   bool doInterpolate = false;
-   if (interpolationPoints > 1) {
-       doInterpolate = true;
-   }
-   
+
+   const auto doInterpolate = interpolationPoints > 1;
+
    /***********************************************************************
     * Step 2:
     * Load geometry and data from Eclipse file
     */
 
-   
-   // Read data from the Eclipse file and 
+
+   // Read data from the Eclipse file and
    // populate our vectors with data from the file
-  
+
    // Test if filename exists and is readable
-   ifstream eclipsefile(ECLIPSEFILENAME, ios::in);
-   if (eclipsefile.fail()) {
-        std::stringstream str;
-        str << "Error: Filename " << ECLIPSEFILENAME << " not found or not readable.";
-        throw str.str();
+   start = clock();
+
+   auto       deck = parseEclipseFile(ECLIPSEFILENAME, helper.isMaster);
+   const auto res  = getCartesianDimension(deck);
+
+   finish   = clock();
+   timeused = (double(finish) - double(start)) / CLOCKS_PER_SEC;
+   if (helper.isMaster) {
+       cout << " (" << timeused << " secs)" << endl;
    }
-   eclipsefile.close(); 
 
-   if (helper.isMaster) cout << "Parsing Eclipse file <" << ECLIPSEFILENAME << "> ... ";
-   flush(cout);   start = clock();
-   Opm::ParseContext parseMode;
-   auto parser = std::make_shared<Opm::Parser>();
-   Opm::addNonStandardUpscalingKeywords(*parser);
-   Opm::DeckConstPtr deck(parser->parseFile(ECLIPSEFILENAME , parseMode));
-   finish = clock();   timeused = (double(finish)-double(start))/CLOCKS_PER_SEC;
-   if (helper.isMaster) cout << " (" << timeused <<" secs)" << endl;
+   {
+       const double minPerm = atof(options["minPerm"].c_str());
+       const double maxPerm = atof(options["maxPerm"].c_str());
+       const double minPoro = atof(options["minPoro"].c_str());
 
-   const auto& specgridRecord = deck->getKeyword("SPECGRID").getRecord(0);
-   std::array<int,3> res;
-   res[0] = specgridRecord.getItem("NX").get< int >(0);
-   res[1] = specgridRecord.getItem("NY").get< int >(0);
-   res[2] = specgridRecord.getItem("NZ").get< int >(0);
-
-   const double minPerm = atof(options["minPerm"].c_str());
-   const double maxPerm = atof(options["maxPerm"].c_str());
-   const double minPoro = atof(options["minPoro"].c_str());
-
-   helper.sanityCheckInput(deck, minPerm, maxPerm, minPoro);
+       helper.sanityCheckInput(deck, minPerm, maxPerm, minPoro);
+   }
 
    /***************************************************************************
     * Step 3:
     * Load relperm- and J-function-curves for the stone types.
-    * We read columns from text-files, syntax allowed is determined 
-    * by MonotCubicInterpolator which actually opens and parses the 
+    * We read columns from text-files, syntax allowed is determined
+    * by MonotCubicInterpolator which actually opens and parses the
     * text files.
     *
     * If a standard eclipse data file is given as input, the data columns
@@ -422,143 +610,86 @@ try
     *
     * If output from this very program is given as input, then the data columns read
     *   Pc    Sw    Krx   Kry   Krz
-    * 
+    *
     * (and the option -relPermCurve and -jFunctionCurve are ignored)
-    * 
+    *
     * How do we determine which mode of operation?
     *  - If PERMY and PERMZ are present in grdecl-file, we are in the anisotropic mode
-    *  
+    *
     */
 
    // Number of stone-types is max(satnums):
-   
+
    // If there is only one J-function supplied on the command line,
    // use that for all stone types.
 
-   int stone_types = int(*(max_element(helper.satnums.begin(), helper.satnums.end())));
-   
-   std::vector<string> JfunctionNames; // Placeholder for the names of the loaded J-functions.
+   const auto stone_types =
+       static_cast<int>(*(max_element(helper.satnums.begin(),
+                                      helper.satnums.end())));
 
-   // This decides whether we are upscaling water or oil relative permeability
-   const int relPermCurve = atoi(options["relPermCurve"].c_str());
    // This decides whether we are upscaling both phases in this run or only one
    helper.upscaleBothPhases = (options["upscaleBothPhases"] == "true");
-
-   const int jFunctionCurve        = atoi(options["jFunctionCurve"].c_str());
-   helper.points                   = atoi(options["points"].c_str());
-   const double gravity            = atof(options["gravity"].c_str());
+   helper.points            = atoi(options["points"].c_str());
 
    // Input for surfaceTension is dynes/cm
-   // SI units are Joules/square metre
-   const double surfaceTension     = atof(options["surfaceTension"].c_str()) * 1e-3; // multiply with 10^-3 to obtain SI units 
-   const bool includeGravity       = (fabs(gravity) > DBL_MIN); // true for non-zero gravity
-   const int outputprecision       = atoi(options["outputprecision"].c_str());
+   // SI units are Joules/square metre => multiply with 10^-3 to obtain SI units.
+   const double surfaceTension = atof(options["surfaceTension"].c_str()) * 1e-3;
+
+   const double gravity      = atof(options["gravity"].c_str());
+   const bool includeGravity = (std::fabs(gravity) > DBL_MIN); // true for non-zero gravity
+
+   const int outputprecision = atoi(options["outputprecision"].c_str());
 
    // Handle two command line input formats, either one J-function for all stone types
    // or one each. If there is only one stone type, both code blocks below are equivalent.
-   
-   if (varnum != rockfileindex + stone_types && varnum != rockfileindex + 1)
+
+   if (! ((varnum == rockfileindex + stone_types) ||
+          (varnum == rockfileindex + 1          )))
+   {
        throw std::runtime_error("Error:  Wrong number of stone-functions provided.");
-
-   for (int i=0 ; i < stone_types; ++i) {
-      const char* ROCKFILENAME = vararg[rockfileindex+stone_types==varnum?rockfileindex+i:rockfileindex];
-      // Check if rock file exists and is readable:
-      ifstream rockfile(ROCKFILENAME, ios::in);
-      if (rockfile.fail()) {
-         std::stringstream str;
-         str << "Error: Filename " << ROCKFILENAME << " not found or not readable.";
-         throw std::runtime_error(str.str());
-      }
-      rockfile.close();
-
-      if (! helper.anisotropic_input) {
-         MonotCubicInterpolator Jtmp;
-         try {
-             Jtmp = MonotCubicInterpolator(ROCKFILENAME, 1, jFunctionCurve);
-         }
-         catch (const char * errormessage) {
-             std::stringstream str;
-             str << "Error: " << errormessage << endl
-                 << "Check filename and -jFunctionCurve" << endl;
-             throw std::runtime_error(str.str());
-         }
-         
-         // Invert J-function, now we get saturation as a function of pressure:
-         if (Jtmp.isStrictlyMonotone()) {
-             helper.InvJfunctions.push_back(MonotCubicInterpolator(Jtmp.get_fVector(), Jtmp.get_xVector()));
-             JfunctionNames.push_back(ROCKFILENAME);
-             if (helper.upscaleBothPhases) {
-                 helper.Krfunctions[0][0].push_back(MonotCubicInterpolator(ROCKFILENAME, 1, 2));
-                 helper.Krfunctions[0][1].push_back(MonotCubicInterpolator(ROCKFILENAME, 1, 3));
-             }
-             else {
-                 helper.Krfunctions[0][0].push_back(MonotCubicInterpolator(ROCKFILENAME, 1, relPermCurve));
-             }
-         }
-         else {
-             std::stringstream str;
-             str << "Error: Jfunction " << i+1 << " in rock file " << ROCKFILENAME << " was not invertible.";
-             throw std::runtime_error(str.str());
-         }
-      }
-      else {  // If input is anisotropic, then we are in second mode with different input file format
-         MonotCubicInterpolator Pctmp;
-         try {
-             Pctmp = MonotCubicInterpolator(ROCKFILENAME, 2, 1);
-         }
-         catch (const char * errormessage) {
-             std::stringstream str;
-             str << "Error: " << errormessage << endl
-                 << "Check filename and columns 1 and 2 (Pc and " << helper.saturationstring <<")";
-             throw str.str();
-         }
-
-         // Invert Pc(Sw) curve into Sw(Pc):
-         if (Pctmp.isStrictlyMonotone()) {
-             helper.SwPcfunctions.push_back(MonotCubicInterpolator(Pctmp.get_fVector(), Pctmp.get_xVector()));
-             JfunctionNames.push_back(ROCKFILENAME);
-             helper.Krfunctions[0][0].push_back(MonotCubicInterpolator(ROCKFILENAME, 2, 3));
-             helper.Krfunctions[1][0].push_back(MonotCubicInterpolator(ROCKFILENAME, 2, 4));
-             helper.Krfunctions[2][0].push_back(MonotCubicInterpolator(ROCKFILENAME, 2, 5));
-             if (helper.upscaleBothPhases) {
-                 helper.Krfunctions[0][1].push_back(MonotCubicInterpolator(ROCKFILENAME, 2, 6));
-                 helper.Krfunctions[1][1].push_back(MonotCubicInterpolator(ROCKFILENAME, 2, 7));
-                 helper.Krfunctions[2][1].push_back(MonotCubicInterpolator(ROCKFILENAME, 2, 8));
-             }
-         }
-         else {
-             std::stringstream str;
-             str << "Error: Pc(" << helper.saturationstring << ") curve " << i+1 << " in rock file " << ROCKFILENAME << " was not invertible.";
-             throw std::runtime_error(str.str());
-         }
-      }
    }
-   
-   // Check if input relperm curves satisfy Eclipse requirement of specifying critical saturations
-   if (helper.doEclipseCheck)
+
+   // Placeholder for the names of the loaded J-functions.
+   std::vector<string> JfunctionNames;
+   {
+       // This decides whether we are upscaling water or oil relative permeability
+       const int relPermCurve   = atoi(options["relPermCurve"].c_str());
+       const int jFunctionCurve = atoi(options["jFunctionCurve"].c_str());
+
+       extractSaturationFunctions(varnum, vararg,
+                                  rockfileindex, stone_types,
+                                  jFunctionCurve, relPermCurve,
+                                  JfunctionNames, helper);
+   }
+
+   // Check if input relperm curves satisfy ECLIPSE requirement of
+   // specifying critical saturations
+   if (helper.doEclipseCheck) {
        helper.checkCriticalSaturations();
+   }
 
    /*****************************************************************************
     * Step 4:
     * Generate tesselated grid:
-    * This is a step needed for the later discretization code to figure out which 
+    * This is a step needed for the later discretization code to figure out which
     * cells are connected to which. Each cornerpoint-cell is tesselated into 8 tetrahedrons.
-    * 
+    *
     * In case of non-zero gravity, calculate z-values of every cell:
     *   1) Compute height of model by averaging z-values of the top layer corners.
     *   2) Calculate density difference between phases in SI-units
     *   3) Go through each cell and find the z-values of the eight corners of the cell.
-    *      Set height of cell equal to average of z-values of the corners minus half of 
+    *      Set height of cell equal to average of z-values of the corners minus half of
     *      model height. Now the cell height is relative to model centre.
-    *      Set pressure difference for the cell equal to density difference times gravity 
+    *      Set pressure difference for the cell equal to density difference times gravity
     *      constant times cell height times factor 10^-7 to obtain bars (same as p_c)
     */
 
    timeused_tesselation = helper.tesselateGrid(deck);
 
    /* If gravity is to be included, calculate z-values of every cell: */
-   if (includeGravity)
+   if (includeGravity) {
        helper.calculateCellPressureGradients(res);
+   }
 
    /******************************************************************************
     * Step 5:
@@ -589,7 +720,7 @@ try
     */
 
    helper.upscaleCapillaryPressure();
-   
+
    /*****************************************************************************
     * Step 7:
     * Upscale single phase permeability
@@ -603,13 +734,13 @@ try
 
    /*****************************************************************
     * Step 8:
-    * 
+    *
     * Loop through a given number of uniformly distributed saturation points
     * and upscale relative permeability for each of them.
     *    a: Make vector of capillary pressure points corresponding to uniformly
     *       distributed water saturation points between saturation endpoints.
     *    b: Loop over capillary pressure points
-    *       1)  Loop over all cells to find the saturation value given the 
+    *       1)  Loop over all cells to find the saturation value given the
     *           capillary pressure found in (a). Given the saturation value, find the
     *           phase permeability in the cell given input relperm curve and input
     *           permeability values.
@@ -618,17 +749,19 @@ try
     */
 
     double avg_upscaling_time_pr_point;
-    std::tie(timeused_upscale_wallclock, avg_upscaling_time_pr_point) =
-                helper.upscalePermeability(mpi_rank);
+    std::tie(timeused_upscale_wallclock,
+             avg_upscaling_time_pr_point) =
+        helper.upscalePermeability(mpi_rank);
 
-   /* 
+   /*
     * Step 8c: Make relperm values from phaseperms
     *          (only master node can do this)
     */
    std::array<vector<vector<double>>,2> RelPermValues;
    RelPermValues[0] = helper.getRelPerm(0);
-   if (helper.upscaleBothPhases)
+   if (helper.upscaleBothPhases) {
        RelPermValues[1] = helper.getRelPerm(1);
+   }
 
    /*********************************************************************************
     *  Step 9
@@ -639,215 +772,377 @@ try
     */
    if (helper.isMaster) {
        stringstream outputtmp;
-       
-       // Print a table of all computed values:
-       outputtmp << "######################################################################" << endl;
-       outputtmp << "# Results from upscaling relative permeability."<< endl;
-       outputtmp << "#" << endl;
-#if HAVE_MPI
-       outputtmp << "#          (MPI-version)" << endl;
-#endif
-       time_t now = std::time(NULL);
-       outputtmp << "# Finished: " << asctime(localtime(&now));
-       
-       utsname hostname;   uname(&hostname);
-       outputtmp << "# Hostname: " << hostname.nodename << endl;
-       
-       outputtmp << "#" << endl;
-       outputtmp << "# Eclipse file: " << ECLIPSEFILENAME << endl;
-       outputtmp << "#        cells: " << helper.tesselatedCells << endl;
-       outputtmp << "#  Pore volume: " << helper.poreVolume << endl;
-       outputtmp << "#       volume: " << helper.volume << endl;
-       outputtmp << "#     Porosity: " << helper.poreVolume/helper.volume << endl;
-       outputtmp << "#" << endl;
-       if (! helper.anisotropic_input) {
-           for (int i=0; i < stone_types ; ++i) {
-               outputtmp << "# Stone " << i+1 << ": " << JfunctionNames[i] << " (" << helper.InvJfunctions[i].getSize() << " points)" <<  endl;
-           }
-           outputtmp << "#         jFunctionCurve: " << options["jFunctionCurve"] << endl;
-           if (!helper.upscaleBothPhases) outputtmp << "#           relPermCurve: " << options["relPermCurve"] << endl;
-       }
-       else { // anisotropic input, not J-functions that are supplied on command line (but vector JfunctionNames is still used)
-           for (int i=0; i < stone_types ; ++i) {
-               outputtmp << "# Stone " << i+1 << ": " << JfunctionNames[i] << " (" << helper.Krfunctions[0][0][i].getSize() << " points)" <<  endl;
-           }
-       }
-           
-       outputtmp << "#" << endl;
-       outputtmp << "# Timings:   Tesselation: " << timeused_tesselation << " secs" << endl;
-       outputtmp << "#              Upscaling: " << timeused_upscale_wallclock << " secs";
-#ifdef HAVE_MPI
-       outputtmp << " (wallclock time)" << endl;
-       outputtmp << "#                         " << avg_upscaling_time_pr_point << " secs pr. saturation point" << endl;
-       outputtmp << "#              MPI-nodes: " << mpi_nodecount << endl;
 
-       // Single phase upscaling time is included here, in possibly a hairy way.
-       double speedup = (avg_upscaling_time_pr_point * (helper.points + 1) + timeused_tesselation)/(timeused_upscale_wallclock + avg_upscaling_time_pr_point + timeused_tesselation);
-       outputtmp << "#                Speedup: " << speedup << ", efficiency: " << speedup/mpi_nodecount << endl;
-#else
-       outputtmp << ", " << avg_upscaling_time_pr_point << " secs avg for " << helper.points << " runs" << endl;
-#endif
-       outputtmp << "# " << endl;
-       outputtmp << "# Options used:" << endl;
-       outputtmp << "#     Boundary conditions: ";
-       if (isFixed)    outputtmp << "Fixed (no-flow)" << endl;
-       if (isPeriodic) outputtmp << "Periodic" << endl;
-       if (isLinear)   outputtmp << "Linear" << endl;
-       outputtmp << "#                  points: " << options["points"] << endl;
-       outputtmp << "#         maxPermContrast: " << options["maxPermContrast"] << endl;
-       outputtmp << "#                 minPerm: " << options["minPerm"] << endl;
-       outputtmp << "#                 minPoro: " << options["minPoro"] << endl;
-       outputtmp << "#          surfaceTension: " << options["surfaceTension"] << " dynes/cm" << endl;
-       if (includeGravity) {
-           outputtmp << "#                 gravity: " << options["gravity"] << " m/s²" << endl;
-           if (owsystem) outputtmp << "#            waterDensity: " << options["waterDensity"] << " g/cm³" << endl;
-           else outputtmp << "#              gasDensity: " << options["waterDensity"] << " g/cm³" << endl;
-           outputtmp << "#              oilDensity: " << options["oilDensity"] << " g/cm³" << endl;
+       // Print a table of all computed values:
+       outputtmp << "######################################################################\n"
+                 << "# Results from upscaling relative permeability.\n"
+                 << "#\n";
+
+#if defined(HAVE_MPI) && HAVE_MPI
+       outputtmp << "#          (MPI-version)\n";
+#endif  // HAVE_MPI
+
+       {
+           time_t now = std::time(NULL);
+           outputtmp << "# Finished: " << asctime(localtime(&now));
+       }
+
+       {
+           utsname hostname;   uname(&hostname);
+           outputtmp << "# Hostname: " << hostname.nodename << endl;
+       }
+
+       outputtmp << "#" << '\n'
+                 << "# ECLIPSE file: " << ECLIPSEFILENAME << '\n'
+                 << "#        cells: " << helper.tesselatedCells << '\n'
+                 << "#  Pore volume: " << helper.poreVolume << '\n'
+                 << "#       volume: " << helper.volume << '\n'
+                 << "#     Porosity: " << (helper.poreVolume / helper.volume) << '\n'
+                 << "#\n";
+
+       if (! helper.anisotropic_input) {
+           const auto& invJ = helper.InvJfunctions;
+
+           for (int i = 0; i < stone_types ; ++i) {
+               outputtmp << "# Stone " << (i + 1) << ": "
+                         << JfunctionNames[i]
+                         << " (" << invJ[i].getSize() << " points)\n";
+           }
+
+           outputtmp << "#         jFunctionCurve: "
+                     << options["jFunctionCurve"] << '\n';
+
+           if (! helper.upscaleBothPhases) {
+               outputtmp << "#           relPermCurve: "
+                         << options["relPermCurve"] << '\n';
+           }
        }
        else {
-           outputtmp << "#                 gravity: 0" << endl;
+           // anisotropic input, not J-functions that are supplied on
+           // command line (but vector JfunctionNames is still used)
+
+           const auto& kr = helper.Krfunctions[0][0];
+
+           for (int i = 0; i < stone_types ; ++i) {
+               outputtmp << "# Stone " << (i + 1) << ": "
+                         << JfunctionNames[i]
+                         << " (" << kr[i].getSize() << " points)\n";
+           }
        }
+
+       outputtmp << "#" << '\n'
+                 << "# Timings:   Tesselation: "
+                 << timeused_tesselation << " secs" << '\n'
+                 << "#              Upscaling: "
+                 << timeused_upscale_wallclock << " secs";
+
+#ifdef HAVE_MPI
+       outputtmp << " (wallclock time)\n"
+                 << "#                         "
+                 << avg_upscaling_time_pr_point
+                 << " secs pr. saturation point" << '\n'
+                 << "#              MPI-nodes: "
+                 << mpi_nodecount << '\n';
+
+       // Single phase upscaling time is included here, in possibly a hairy
+       // way.
+       const auto speedup =
+           (avg_upscaling_time_pr_point * (helper.points + 1) + timeused_tesselation)
+           / (timeused_upscale_wallclock +
+              avg_upscaling_time_pr_point +
+              timeused_tesselation);
+
+       outputtmp << "#                Speedup: " << speedup
+                 << ", efficiency: " << (speedup / mpi_nodecount) << endl;
+
+#else // !HAVE_MPI
+
+       outputtmp << ", " << avg_upscaling_time_pr_point
+                 << " secs avg for " << helper.points
+                 << " runs" << endl;
+
+#endif // HAVE_MPI
+
+       outputtmp << "#\n"
+                 << "# Options used:\n"
+                 << "#     Boundary conditions: ";
+
+       if (isFixed)    { outputtmp << "Fixed (no-flow)\n"; }
+       if (isPeriodic) { outputtmp << "Periodic\n"; }
+       if (isLinear)   { outputtmp << "Linear\n"; }
+
+       outputtmp << "#                  points: " << options["points"] << '\n'
+                 << "#         maxPermContrast: " << options["maxPermContrast"] << '\n'
+                 << "#                 minPerm: " << options["minPerm"] << " [mD]\n"
+                 << "#                 minPoro: " << options["minPoro"] << '\n'
+                 << "#          surfaceTension: " << options["surfaceTension"] << " dynes/cm\n";
+
+       if (includeGravity) {
+           outputtmp << "#                 gravity: "
+                     << options["gravity"] << " m/s²\n";
+
+           if (owsystem) {
+               outputtmp << "#            waterDensity: "
+                         << options["waterDensity"] << " g/cm³\n";
+           }
+           else {
+               outputtmp << "#              gasDensity: "
+                         << options["waterDensity"] << " g/cm³\n";
+           }
+
+           outputtmp << "#              oilDensity: "
+                     << options["oilDensity"] << " g/cm³\n";
+       }
+       else {
+           outputtmp << "#                 gravity: 0\n";
+       }
+
        if (doInterpolate) {
-           outputtmp << "#             interpolate: " << options["interpolate"] << " points" << endl;
+           outputtmp << "#             interpolate: "
+                     << options["interpolate"] << " points\n";
        }
-       outputtmp << "# " << endl;
-       outputtmp << "# Single phase permeability" << endl; 
-       outputtmp << "#  |Kxx  Kxy  Kxz| = " << helper.permTensor(0,0) << "  " << helper.permTensor(0,1) << "  " << helper.permTensor(0,2) << endl; 
-       outputtmp << "#  |Kyx  Kyy  Kyz| = " << helper.permTensor(1,0) << "  " << helper.permTensor(1,1) << "  " << helper.permTensor(1,2) << endl; 
-       outputtmp << "#  |Kzx  Kzy  Kzz| = " << helper.permTensor(2,0) << "  " << helper.permTensor(2,1) << "  " << helper.permTensor(2,2) << endl; 
-       outputtmp << "# " << endl;
+
+       {
+           auto mD = [](const double k)
+           {
+               return Opm::unit::convert::to(k, Opm::prefix::milli*Opm::unit::darcy);
+           };
+
+           outputtmp << "#\n"
+                     << "# Single phase permeability (mD)\n"
+                     << "#  |Kxx  Kxy  Kxz| = "
+                     << mD(helper.permTensor(0,0)) << "  "
+                     << mD(helper.permTensor(0,1)) << "  "
+                     << mD(helper.permTensor(0,2)) << '\n';
+
+           outputtmp << "#  |Kyx  Kyy  Kyz| = "
+                     << mD(helper.permTensor(1,0)) << "  "
+                     << mD(helper.permTensor(1,1)) << "  "
+                     << mD(helper.permTensor(1,2)) << '\n';
+
+           outputtmp << "#  |Kzx  Kzy  Kzz| = "
+                     << mD(helper.permTensor(2,0)) << "  "
+                     << mD(helper.permTensor(2,1)) << "  "
+                     << mD(helper.permTensor(2,2)) << '\n';
+
+           outputtmp << "#\n";
+       }
+
        if (doInterpolate) {
-           outputtmp << "# NB: Data points shown are interpolated." << endl;
+           outputtmp << "# NB: Data points shown are interpolated.\n";
        }
-       outputtmp << "######################################################################" << endl;
+
+       outputtmp << "######################################################################\n";
+
        if (helper.upscaleBothPhases) {
            string phase1, phase2;
-           if (owsystem) phase1="w"; else phase1="g";
-           phase2="o";
-           if (isFixed) { 
-               outputtmp << "#  Pc (Pa)        " << helper.saturationstring << "           Kr" << phase1 << "xx       Kr" << phase1 << "yy       Kr" << phase1 << "zz"
-                         <<  "       Kr" << phase2 << "xx       Kr" << phase2 << "yy       Kr" << phase2 << "zz" <<  endl; 
-           } 
-           else if (isPeriodic || isLinear) { 
-               outputtmp << "#  Pc (Pa)        " << helper.saturationstring << "           Kr" << phase1 << "xx       Kr" << phase1 << "yy       Kr" << phase1 << "zz       Kr"
-                         << phase1 << "yz       Kr" << phase1 << "xz       Kr" << phase1 << "xy       Kr" << phase1 << "zy       Kr" << phase1 << "zx       Kr" << phase1 << "yx" 
-                         << "       Kr" << phase2 << "xx       Kr" << phase2 << "yy       Kr" << phase2 << "zz       Kr" 
-                         << phase2 << "yz       Kr" << phase2 << "xz       Kr" << phase2 << "xy       Kr" << phase2 << "zy       Kr" << phase2 << "zx       Kr" << phase2 << "yx" << endl;
+
+           if (owsystem) {
+               phase1 = "w";
+           }
+           else {
+               phase1 = "g";
+           }
+
+           phase2 = "o";
+
+           if (isFixed) {
+               outputtmp << "#  Pc (Pa)        " << helper.saturationstring
+                         << "           Kr" << phase1
+                         << "xx       Kr" << phase1
+                         << "yy       Kr" << phase1
+                         << "zz       Kr" << phase2
+                         << "xx       Kr" << phase2
+                         << "yy       Kr" << phase2
+                         << "zz\n";
+           }
+           else if (isPeriodic || isLinear) {
+               outputtmp << "#  Pc (Pa)        " << helper.saturationstring
+                         << "           Kr" << phase1
+                         << "xx       Kr" << phase1
+                         << "yy       Kr" << phase1
+                         << "zz       Kr" << phase1
+                         << "yz       Kr" << phase1
+                         << "xz       Kr" << phase1
+                         << "xy       Kr" << phase1
+                         << "zy       Kr" << phase1
+                         << "zx       Kr" << phase1
+                         << "yx       Kr" << phase2
+                         << "xx       Kr" << phase2
+                         << "yy       Kr" << phase2
+                         << "zz       Kr" << phase2
+                         << "yz       Kr" << phase2
+                         << "xz       Kr" << phase2
+                         << "xy       Kr" << phase2
+                         << "zy       Kr" << phase2
+                         << "zx       Kr" << phase2
+                         << "yx\n";
            }
        }
        else {
-           if (isFixed) { 
-               outputtmp << "#  Pc (Pa)        " << helper.saturationstring << "            Krxx        Kryy        Krzz" << endl;
-           } 
-           else if (isPeriodic || isLinear) { 
-               outputtmp << "#  Pc (Pa)        " << helper.saturationstring << "            Krxx        Kryy        Krzz        Kryz        Krxz        Krxy        Krzy        Krzx        Kryx" << endl;
+           if (isFixed) {
+               outputtmp << "#  Pc (Pa)        "
+                         << helper.saturationstring
+                         << "            Krxx        Kryy        Krzz\n";
+           }
+           else if (isPeriodic || isLinear) {
+               outputtmp << "#  Pc (Pa)        "
+                         << helper.saturationstring
+                         << "            Krxx        Kryy        Krzz        "
+                         << "Kryz        Krxz        Krxy        Krzy        "
+                         << "Krzx        Kryx\n";
            }
        }
-       
-       vector<double> Pvalues = helper.pressurePoints;
 
-       // Multiply all pressures with the surface tension (potentially) supplied
-       // at the command line. This multiplication has been postponed to here
-       // to avoid division by zero and to avoid special handling of negative
-       // capillary pressure in the code above.
-       std::transform(Pvalues.begin(), Pvalues.end(), Pvalues.begin(), 
-		      std::bind1st(std::multiplies<double>(), surfaceTension));
-       vector<double> Satvalues = helper.WaterSaturation; //.get_fVector(); 
-       
+       auto Pvalues = helper.pressurePoints;
+
+       // Multiply all pressures with the surface tension (potentially)
+       // supplied at the command line. This multiplication has been
+       // postponed to here to avoid division by zero and to avoid special
+       // handling of negative capillary pressure in the code above.
+       for (auto& press : Pvalues) {
+           press *= surfaceTension;
+       }
+
+       auto Satvalues = helper.WaterSaturation; //.get_fVector();
+
        // If user wants interpolated output, do monotone cubic interpolation
-       // by modifying the data vectors that are to be printed
+       // by modifying the data vectors that are to be printed.
        if (doInterpolate) {
-           // Find min and max for saturation values
-           double xmin = +DBL_MAX;
-           double xmax = -DBL_MAX;
-           for (unsigned int i = 0; i < Satvalues.size(); ++i) {
-               if (Satvalues[i] < xmin) {
-                   xmin = Satvalues[i];
+
+           // Split interval between minumum and maximum saturation into
+           // (interpolationPoints - 1) equally sized smaller intervals.
+           auto SatvaluesInterp = std::vector<double>{};
+           {
+               const auto m = std::minmax_element(Satvalues.begin(), Satvalues.end());
+
+               const auto xmin = *m.first;
+               const auto xmax = *m.second;
+
+               // Make uniform grid in saturation axis
+               SatvaluesInterp.reserve(interpolationPoints);
+
+               auto interp = [xmin, xmax, interpolationPoints](const int i) -> double {
+                   const auto t = static_cast<double>(i) / (interpolationPoints - 1);
+
+                   return xmin + t*(xmax - xmin);
+               };
+
+               for (int i = 0; i < interpolationPoints; ++i) {
+                   SatvaluesInterp.push_back(interp(i));
                }
-               if (Satvalues[i] > xmax) {
-                   xmax = Satvalues[i];
+           }
+
+           // Now capillary pressure and computed relperm-values must be
+           // viewed as functions of saturation, and then interpolated on
+           // the uniform saturation grid.
+
+           // Now overwrite existing Pvalues and relperm-data with
+           // interpolated data:
+           {
+               const auto PvaluesVsSaturation =
+                   MonotCubicInterpolator(Satvalues, Pvalues);
+
+               Pvalues.clear();  Pvalues.reserve(SatvaluesInterp.size());
+
+               for (const auto& s : SatvaluesInterp) {
+                   Pvalues.push_back(PvaluesVsSaturation.evaluate(s));
                }
            }
-           // Make uniform grid in saturation axis
-           vector<double> SatvaluesInterp;
-           for (int i = 0; i < interpolationPoints; ++i) {
-               SatvaluesInterp.push_back(xmin + ((double)i)/((double)interpolationPoints-1)*(xmax-xmin));
-           }
-           // Now capillary pressure and computed relperm-values must be viewed as functions
-           // of saturation, and then interpolated on the uniform saturation grid.
-           
-           // Now overwrite existing Pvalues and relperm-data with interpolated data:
-           MonotCubicInterpolator PvaluesVsSaturation(Satvalues, Pvalues);
-           Pvalues.clear();
-           for (int i = 0; i < interpolationPoints; ++i) {
-               Pvalues.push_back(PvaluesVsSaturation.evaluate(SatvaluesInterp[i]));
-           }
+
            for (int voigtIdx = 0; voigtIdx < helper.tensorElementCount; ++voigtIdx) {
-               MonotCubicInterpolator RelPermVsSaturation(Satvalues, RelPermValues[0][voigtIdx]);
-               RelPermValues[0][voigtIdx].clear();
-               for (int i=0; i < interpolationPoints; ++i) {
-                   RelPermValues[0][voigtIdx].push_back(RelPermVsSaturation.evaluate(SatvaluesInterp[i]));
+               auto& kr = RelPermValues[0][voigtIdx];
+
+               const auto RelPermVsSaturation =
+                   MonotCubicInterpolator(Satvalues, kr);
+
+               kr.clear();  kr.reserve(SatvaluesInterp.size());
+
+               for (const auto& s : SatvaluesInterp) {
+                   kr.push_back(RelPermVsSaturation.evaluate(s));
                }
            }
+
            if (helper.upscaleBothPhases) {
                for (int voigtIdx = 0; voigtIdx < helper.tensorElementCount; ++voigtIdx) {
-                   MonotCubicInterpolator RelPermVsSaturation(Satvalues, RelPermValues[1][voigtIdx]);
-                   RelPermValues[1][voigtIdx].clear();
-                   for (int i=0; i < interpolationPoints; ++i) {
-                       RelPermValues[1][voigtIdx].push_back(RelPermVsSaturation.evaluate(SatvaluesInterp[i]));
+                   auto& kr = RelPermValues[1][voigtIdx];
+
+                   const auto RelPermVsSaturation =
+                       MonotCubicInterpolator(Satvalues, kr);
+
+                   kr.clear();  kr.reserve(SatvaluesInterp.size());
+
+                   for (const auto& s : SatvaluesInterp) {
+                       kr.push_back(RelPermVsSaturation.evaluate(s));
                    }
                }
            }
-           
+
            // Now also overwrite Satvalues
-           Satvalues.clear();
-           Satvalues = SatvaluesInterp;
+           Satvalues = std::move(SatvaluesInterp);
        }
-       
+
        // The code below does not care whether the data is interpolated or not.
-       const int fieldwidth = outputprecision + 8;
-       for (unsigned int i=0; i < Satvalues.size(); ++i) {
-           outputtmp << showpoint << setw(fieldwidth) << setprecision(outputprecision) << Pvalues[i]; 
-           outputtmp << showpoint << setw(fieldwidth) << setprecision(outputprecision) << Satvalues[i]; 
-           
+       const auto fieldwidth = outputprecision + 8;
+       for (decltype(Satvalues.size())
+                i = 0, n = Satvalues.size(); i < n; ++i)
+       {
+           outputtmp << showpoint << setw(fieldwidth)
+                     << setprecision(outputprecision)
+                     << Pvalues[i];
+
+           outputtmp << showpoint << setw(fieldwidth)
+                     << setprecision(outputprecision)
+                     << Satvalues[i];
+
            for (int voigtIdx = 0; voigtIdx < helper.tensorElementCount; ++voigtIdx) {
-               outputtmp << showpoint << setw(fieldwidth) << setprecision(outputprecision) 
+               outputtmp << showpoint << setw(fieldwidth)
+                         << setprecision(outputprecision)
                          << RelPermValues[0][voigtIdx][i];
-           } 
+           }
+
            if (helper.upscaleBothPhases) {
                for (int voigtIdx = 0; voigtIdx < helper.tensorElementCount; ++voigtIdx) {
-                   outputtmp << showpoint << setw(fieldwidth) << setprecision(outputprecision) 
+                   outputtmp << showpoint << setw(fieldwidth)
+                             << setprecision(outputprecision)
                              << RelPermValues[1][voigtIdx][i];
-               } 
+               }
            }
-           outputtmp << endl; 
-           
+
+           outputtmp << endl;
        }
-       
+
        cout << outputtmp.str();
-       
+
        if (options["output"] != "") {
            cout << "Writing results to " << options["output"] << endl;
+
            ofstream outfile;
+
            outfile.open(options["output"].c_str(), ios::out | ios::trunc);
            outfile << outputtmp.str();
-           outfile.close();      
+           outfile.close();
        }
-       
-       // If both phases are upscaled and output is specyfied, create SWOF or SGOF files for Eclipse
+
+       // If both phases are upscaled and output is specified, create SWOF
+       // or SGOF files for ECLIPSE
        if (options["output"] != "" && helper.upscaleBothPhases) {
-            cout << "Writing Eclipse compatible files to "
-                 << getEclipseOutputFile(options["output"],'X',owsystem?'W':'G')
-                 << ", " << getEclipseOutputFile(options["output"],'Y',owsystem?'W':'G')
-                 << " and " << getEclipseOutputFile(options["output"],'Z',owsystem?'W':'G')<< endl;
-            for (int comp=0;comp<3;++comp)
-                writeEclipseOutput(RelPermValues, Satvalues, Pvalues, options, comp, owsystem);
+            cout << "Writing ECLIPSE compatible files to "
+                 << getEclipseOutputFile(options["output"], 'X', owsystem ? 'W' : 'G')
+                 << ", "
+                 << getEclipseOutputFile(options["output"], 'Y', owsystem ? 'W' : 'G')
+                 << " and "
+                 << getEclipseOutputFile(options["output"], 'Z', owsystem ? 'W' : 'G')
+                 << endl;
+
+            for (int comp = 0; comp < 3; ++comp) {
+                writeEclipseOutput(RelPermValues, Satvalues, Pvalues,
+                                   options, comp, owsystem);
+            }
        }
    }
-
-   return 0;
 }
-catch (const std::exception &e) {
-    std::cerr << e.what() << "\n";
+catch (const std::exception& e) {
+    std::cerr << e.what() << '\n';
     usageandexit();
 }

--- a/examples/upscale_relperm.cpp
+++ b/examples/upscale_relperm.cpp
@@ -1,4 +1,3 @@
-
 /*
   Copyright 2010 Statoil ASA.
 
@@ -59,14 +58,16 @@
  */
 #include <config.h>
 
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <iomanip>
-#include <ctime>
-#include <cmath>
 #include <cfloat> // for DBL_MAX/DBL_MIN
+#include <cmath>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
 #include <map>
+#include <memory>
+#include <sstream>
+
 #include <sys/utsname.h>
 
 #include <opm/common/utility/platform_dependent/disable_warnings.h>

--- a/examples/upscale_relpermvisc.cpp
+++ b/examples/upscale_relpermvisc.cpp
@@ -338,8 +338,8 @@ try
     flush(cout);   start = clock();
  
     Opm::ParseContext parseMode;
-    Opm::ParserPtr parser(new Opm::Parser());
-    Opm::addNonStandardUpscalingKeywords(parser);
+    auto parser = std::make_shared<Opm::Parser>();
+    Opm::addNonStandardUpscalingKeywords(*parser);
     Opm::DeckConstPtr deck(parser->parseFile(ECLIPSEFILENAME , parseMode));
 
     finish = clock();   timeused = (double(finish)-double(start))/CLOCKS_PER_SEC;

--- a/examples/upscale_relpermvisc.cpp
+++ b/examples/upscale_relpermvisc.cpp
@@ -81,7 +81,6 @@
 
 #include <opm/core/utility/MonotCubicInterpolator.hpp>
 
-#include <opm/upscaling/ParserAdditions.hpp>
 #include <opm/upscaling/RelPermUtils.hpp>
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
 
@@ -347,10 +346,7 @@ try
     if (isMaster) cout << "Parsing Eclipse file <" << ECLIPSEFILENAME << "> ... ";
     flush(cout);   start = clock();
  
-    Opm::ParseContext parseMode;
-    auto parser = std::make_shared<Opm::Parser>();
-    Opm::addNonStandardUpscalingKeywords(*parser);
-    Opm::DeckConstPtr deck(parser->parseFile(ECLIPSEFILENAME , parseMode));
+    auto deck = RelPermUpscaleHelper::parseEclipseFile(ECLIPSEFILENAME);
 
     finish = clock();   timeused = (double(finish)-double(start))/CLOCKS_PER_SEC;
     if (isMaster) cout << " (" << timeused <<" secs)" << endl;
@@ -1344,8 +1340,8 @@ try
                 cout << fracFlowRatioTestvalue << "\t" << WaterSaturation[pointidx];
                 // Store and print phase-perm-result
                 for (int voigtIdx=0; voigtIdx < tensorElementCount; ++voigtIdx) { 
-                    PhasePerm[phase][pointidx][voigtIdx] = getVoigtValue(phasePermTensor,voigtIdx); 
-                    cout << "\t" << getVoigtValue(phasePermTensor,voigtIdx); 
+                    PhasePerm[phase][pointidx][voigtIdx] = ::Opm::getVoigtValue(phasePermTensor,voigtIdx);
+                    cout << "\t" << ::Opm::getVoigtValue(phasePermTensor,voigtIdx);
                 } 
                 cout << endl; 
             }
@@ -1429,7 +1425,7 @@ try
                 Matrix phasePermTensor = zeroMatrix;
                 zero(phasePermTensor);
                 for (int voigtIdx = 0; voigtIdx < tensorElementCount; ++voigtIdx) {
-                    setVoigtValue(phasePermTensor, voigtIdx, PhasePerm[phase][idx][voigtIdx]);
+                    ::Opm::setVoigtValue(phasePermTensor, voigtIdx, PhasePerm[phase][idx][voigtIdx]);
                 }
                 //cout << phasePermTensor << endl;
                 Matrix relPermTensor = zeroMatrix;
@@ -1437,7 +1433,7 @@ try
                 // relPermTensor *= permTensorInv;
                 prod(phasePermTensor, permTensorInv, relPermTensor);
                 for (int voigtIdx = 0; voigtIdx < tensorElementCount; ++voigtIdx) {
-                    RelPermValues[phase][voigtIdx].push_back(getVoigtValue(relPermTensor, voigtIdx));
+                    RelPermValues[phase][voigtIdx].push_back(::Opm::getVoigtValue(relPermTensor, voigtIdx));
                 }
                 //cout << relPermTensor << endl;
             }

--- a/examples/upscale_relpermvisc.cpp
+++ b/examples/upscale_relpermvisc.cpp
@@ -68,8 +68,26 @@
  */
 #include <config.h>
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
+#include <dune/common/version.hh>
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
+#include <dune/common/parallel/mpihelper.hh>
+#else
+#include <dune/common/mpihelper.hh>
+#endif
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/core/utility/MonotCubicInterpolator.hpp>
+
+#include <opm/upscaling/ParserAdditions.hpp>
+#include <opm/upscaling/RelPermUtils.hpp>
+#include <opm/upscaling/SinglePhaseUpscaler.hpp>
+
 #include <cfloat>  // FOR DBL_MAX/DBL_MIN
 #include <cmath>
+#include <cstdlib>
 #include <ctime>
 #include <fstream>
 #include <iomanip>
@@ -80,20 +98,10 @@
 
 #include <sys/utsname.h>
 
-#include <opm/core/utility/MonotCubicInterpolator.hpp>
-#include <opm/upscaling/SinglePhaseUpscaler.hpp>
-#include <opm/upscaling/ParserAdditions.hpp>
-#include <opm/upscaling/RelPermUtils.hpp>
-
-#include <dune/common/version.hh>
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
-#include <dune/common/parallel/mpihelper.hh>
-#else
-#include <dune/common/mpihelper.hh>
-#endif
-
 using namespace Opm;
 using namespace std;
+
+namespace {
 
 /**
    The usage() function displays a message with syntax and available 
@@ -144,8 +152,10 @@ void usage()
 
 void usageandexit() {
     usage();
-    exit(1);
+    std::exit(EXIT_FAILURE);
 }
+
+} // namespace anonymous
 
 int main(int varnum, char** vararg)
 try

--- a/examples/upscale_relpermvisc.cpp
+++ b/examples/upscale_relpermvisc.cpp
@@ -1,4 +1,3 @@
-
 /*
   Copyright 2010 Statoil ASA.
 
@@ -69,14 +68,16 @@
  */
 #include <config.h>
 
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <iomanip>
-#include <ctime>
-#include <cmath>
 #include <cfloat>  // FOR DBL_MAX/DBL_MIN
+#include <cmath>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
 #include <map>
+#include <memory>
+#include <sstream>
+
 #include <sys/utsname.h>
 
 #include <opm/core/utility/MonotCubicInterpolator.hpp>

--- a/examples/upscale_steadystate_implicit.cpp
+++ b/examples/upscale_steadystate_implicit.cpp
@@ -46,6 +46,7 @@
 #include <sys/utsname.h>
 
 #include <iostream>
+#include <memory>
 
 #include <dune/common/version.hh>
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
@@ -194,8 +195,8 @@ try
     Opm::ParseContext parseMode;
     Opm::parameter::ParameterGroup param(argc, argv);
     std::string gridfilename = param.get<std::string>("gridfilename");
-    Opm::ParserPtr parser(new Opm::Parser());
-    Opm::addNonStandardUpscalingKeywords(parser);
+    auto parser = std::make_shared<Opm::Parser>();
+    Opm::addNonStandardUpscalingKeywords(*parser);
     Opm::DeckConstPtr deck(parser->parseFile(gridfilename , parseMode));
 
     // Check that we have the information we need from the eclipse file:  

--- a/examples/upscale_steadystate_implicit.cpp
+++ b/examples/upscale_steadystate_implicit.cpp
@@ -34,26 +34,34 @@
 
 #include <config.h>
 
-//#define VERBOSE
-#include <opm/upscaling/SteadyStateUpscalerImplicit.hpp>
-#include <opm/upscaling/SteadyStateUpscalerManagerImplicit.hpp>
-#include <opm/porsol/euler/EulerUpstreamImplicit.hpp>
-#include <opm/porsol/common/SimulatorTraits.hpp>
-#include <opm/core/utility/MonotCubicInterpolator.hpp>
-#include <opm/upscaling/SinglePhaseUpscaler.hpp>
-#include <opm/upscaling/ParserAdditions.hpp>
-
-#include <sys/utsname.h>
-
-#include <iostream>
-#include <memory>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <dune/common/version.hh>
+
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
 #include <dune/common/parallel/mpihelper.hh>
 #else
 #include <dune/common/mpihelper.hh>
 #endif
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/core/utility/MonotCubicInterpolator.hpp>
+
+#include <opm/porsol/common/SimulatorTraits.hpp>
+#include <opm/porsol/euler/EulerUpstreamImplicit.hpp>
+
+#include <opm/upscaling/ParserAdditions.hpp>
+#include <opm/upscaling/SinglePhaseUpscaler.hpp>
+#include <opm/upscaling/SteadyStateUpscalerImplicit.hpp>
+#include <opm/upscaling/SteadyStateUpscalerManagerImplicit.hpp>
+
+#include <cassert>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+
+#include <sys/utsname.h>
 
 namespace Opm {
     template <class IsotropyPolicy>
@@ -77,6 +85,8 @@ namespace Opm {
 
 using namespace Opm;
 
+namespace {
+
 void usage()
 {
     std::cout << "Usage: upscale_steadystate_implicit gridfilename=filename.grdecl\n"
@@ -87,7 +97,7 @@ void usage()
 
 void usageandexit() {
     usage();
-    exit(1);
+    std::exit(EXIT_FAILURE);
 }
 
 // Assumes that permtensor_t use C ordering.
@@ -149,7 +159,7 @@ std::vector<std::vector<double> > getExtremeSats(std::string rock_list, std::vec
             catch (const char * errormessage) {
                 std::cerr << "Error: " << errormessage << std::endl;
                 std::cerr << "Check filename" << std::endl;
-                exit(1);
+                std::exit(EXIT_FAILURE);
             }
             rocksatendp[i][0] = Jtmp.getMinimumX().first;
             rocksatendp[i][1] = Jtmp.getMaximumX().first;
@@ -166,7 +176,7 @@ std::vector<std::vector<double> > getExtremeSats(std::string rock_list, std::vec
             catch (const char * errormessage) {
                 std::cerr << "Error: " << errormessage << std::endl;
                 std::cerr << "Check filename and columns 1 and 2 (Pc and Sw)" << std::endl;
-                exit(1);
+                std::exit(EXIT_FAILURE);
             }
             rocksatendp[i][0] = Pctmp.getMinimumX().first;
             rocksatendp[i][1] = Pctmp.getMaximumX().first;
@@ -174,6 +184,8 @@ std::vector<std::vector<double> > getExtremeSats(std::string rock_list, std::vec
     }
     return rocksatendp;
 }
+
+} // namespace anonymous
 
 template <typename T>
 std::string toString(T const& value) {

--- a/examples/upscale_steadystate_implicit.cpp
+++ b/examples/upscale_steadystate_implicit.cpp
@@ -31,8 +31,8 @@
   You should have received a copy of the GNU General Public License
   along with OpenRS.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <config.h>
 
+#include <config.h>
 
 //#define VERBOSE
 #include <opm/upscaling/SteadyStateUpscalerImplicit.hpp>
@@ -42,7 +42,9 @@
 #include <opm/core/utility/MonotCubicInterpolator.hpp>
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
 #include <opm/upscaling/ParserAdditions.hpp>
+
 #include <sys/utsname.h>
+
 #include <iostream>
 
 #include <dune/common/version.hh>
@@ -52,33 +54,34 @@
 #include <dune/common/mpihelper.hh>
 #endif
 
-namespace Opm{
-	template <class IsotropyPolicy>
+namespace Opm {
+    template <class IsotropyPolicy>
     struct Implicit
     {
         template <class GridInterface, class BoundaryConditions>
         struct TransportSolver
         {
-            //enum { Dimension = GridInterface::Dimension };
-        	enum { Dimension = GridInterface::Dimension };
+            enum { Dimension = GridInterface::Dimension };
             typedef typename IsotropyPolicy::template ResProp<Dimension>::Type RP;
 
             typedef EulerUpstreamImplicit<GridInterface,
-                                  RP,
-                                  BoundaryConditions> Type;
+                                          RP,
+                                          BoundaryConditions> Type;
 
         };
     };
-	typedef SimulatorTraits<Isotropic, Implicit> UpscalingTraitsBasicImplicit;
+
+    typedef SimulatorTraits<Isotropic, Implicit> UpscalingTraitsBasicImplicit;
 }
+
 using namespace Opm;
 
 void usage()
 {
-    std::cout << "Usage: upscale_steadystate_implicit gridfilename=filename.grdecl  " << std::endl;
-    std::cout << "       rock_list=rocklist.txt [outputWater=] [outputOil=] " << std::endl;
-    std::cout << "       [bc=fixed] [num_sats=10] [num_pdrops=10] " << std::endl;
-    std::cout << "       [anisotropicrocks=false]" << std::endl;
+    std::cout << "Usage: upscale_steadystate_implicit gridfilename=filename.grdecl\n"
+              << "       rock_list=rocklist.txt [outputWater=] [outputOil=]\n"
+              << "       [bc=fixed] [num_sats=10] [num_pdrops=10]\n"
+              << "       [anisotropicrocks=false]" << std::endl;
 }
 
 void usageandexit() {

--- a/opm/porsol/common/ImplicitTransportDefs.cpp
+++ b/opm/porsol/common/ImplicitTransportDefs.cpp
@@ -1,0 +1,25 @@
+#include <config.h>
+
+#include <opm/porsol/common/ImplicitTransportDefs.hpp>
+
+#include <opm/core/grid.h>
+
+#include <algorithm>
+#include <cassert>
+
+void
+Opm::compute_porevolume(const UnstructuredGrid* g,
+                        const Rock&             rock,
+                        std::vector<double>&    porevol)
+{
+    const auto& poro = rock.poro();
+
+    assert (poro.size() == (::std::size_t)(g->number_of_cells));
+
+    porevol.resize(rock.poro().size());
+
+    ::std::transform(poro.begin(), poro.end(),
+                     g->cell_volumes,
+                     porevol.begin(),
+                     ::std::multiplies<double>());
+}

--- a/opm/porsol/common/ImplicitTransportDefs.cpp
+++ b/opm/porsol/common/ImplicitTransportDefs.cpp
@@ -1,3 +1,22 @@
+/*
+  Copyright 2010 Statoil ASA.
+
+  This file is part of The Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #include <config.h>
 
 #include <opm/porsol/common/ImplicitTransportDefs.hpp>

--- a/opm/porsol/common/ImplicitTransportDefs.hpp
+++ b/opm/porsol/common/ImplicitTransportDefs.hpp
@@ -208,7 +208,7 @@ namespace Opm {
             params.insertParameter("linsolver_tolerance",
                                    boost::lexical_cast<std::string>(5.0e-9));
 
-            params.insertParameter("linsoler_verbosity",
+            params.insertParameter("linsolver_verbosity",
                                    boost::lexical_cast<std::string>(1));
 
             params.insertParameter("linsolver_type",

--- a/opm/porsol/common/ImplicitTransportDefs.hpp
+++ b/opm/porsol/common/ImplicitTransportDefs.hpp
@@ -1,279 +1,265 @@
-
 #ifndef OPENRS_IMPLICITTRANSPORTDEFS_HEADER
 #define OPENRS_IMPLICITTRANSPORTDEFS_HEADER
 
-#include <opm/porsol/common/ReservoirPropertyCapillary.hpp>
-#include <opm/core/linalg/LinearSolverIstl.hpp>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+
+#include <dune/common/fvector.hh>
+#include <dune/common/fmatrix.hh>
+
 #include <dune/istl/operators.hh>
 #include <dune/istl/solvers.hh>
 #include <dune/istl/bvector.hh>
 #include <dune/istl/bcrsmatrix.hh>
 #include <dune/istl/preconditioners.hh>
-#include <dune/common/fvector.hh>
-#include <dune/common/fmatrix.hh>
-#include <opm/core/utility/parameters/ParameterGroup.hpp>
+
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
 #include <dune/grid/common/GridAdapter.hpp>
+
+#include <opm/core/grid.h>
+#include <opm/core/linalg/LinearSolverIstl.hpp>
 #include <opm/core/linalg/sparse_sys.h>
 #include <opm/core/pressure/tpfa/ifs_tpfa.h>
 #include <opm/core/pressure/tpfa/trans_tpfa.h>
 #include <opm/core/transport/implicit/NormSupport.hpp>
 #include <opm/core/transport/implicit/ImplicitTransport.hpp>
+#include <opm/core/utility/parameters/ParameterGroup.hpp>
+
+#include <opm/porsol/common/ReservoirPropertyCapillary.hpp>
+
+#include <algorithm>
+#include <cstddef>
 #include <memory>
+#include <string>
+#include <vector>
 
-#if 0
-template <class Ostream, class Collection>
-Ostream&
-operator<<(Ostream& os, const Collection& c)
-{
-    typedef typename Collection::value_type VT;
+#include <boost/lexical_cast.hpp>
 
-    os << "[ ";
-    std::copy(c.begin(), c.end(), ::std::ostream_iterator<VT>(os, " "));
-    os << "]";
+namespace Opm {
+    template <class Vector>
+    class MaxNormStl {
+    public:
+        static double
+        norm(const Vector& v) {
+            return  ImplicitTransportDefault::AccumulationNorm <Vector,  ImplicitTransportDefault::MaxAbs>::norm(v);
+        }
+    };
 
-    return os;
-}
-#endif
-namespace Opm{
-template <class Vector>
-class MaxNormStl {
-	public:
-	    static double
-	    norm(const Vector& v) {
-		return  ImplicitTransportDefault::AccumulationNorm <Vector,  ImplicitTransportDefault::MaxAbs>::norm(v);
-	    }
-};
+    template <class Vector>
+    class MaxNormDune {
+    public:
+        static double
+        norm(const Vector& v) {
+            return v.infinity_norm();
+        }
+    };
 
-template <class Vector>
-class MaxNormDune {
-public:
-    static double
-    norm(const Vector& v) {
-        return v.infinity_norm();
-    }
-};
+    template <int np = 2>
+    class ReservoirState {
+    public:
+        ReservoirState(const UnstructuredGrid* g)
+            : press_ (g->number_of_cells),
+              fpress_(g->number_of_faces),
+              flux_  (g->number_of_faces),
+              sat_   (np * g->number_of_cells)
+        {}
 
-template <int np = 2>
-class ReservoirState { 
-public:
-    ReservoirState(const UnstructuredGrid* g)
-        : press_ (g->number_of_cells),
-          fpress_(g->number_of_faces),
-          flux_  (g->number_of_faces),
-          sat_   (np * g->number_of_cells)
-    {}
+        ::std::vector<double>& pressure    () { return press_ ; }
+        ::std::vector<double>& facepressure() { return fpress_; }
+        ::std::vector<double>& faceflux    () { return flux_  ; }
+        ::std::vector<double>& saturation  () { return sat_   ; }
 
-    ::std::vector<double>& pressure    () { return press_ ; }
-    ::std::vector<double>& facepressure() { return fpress_; }
-    ::std::vector<double>& faceflux    () { return flux_  ; }
-    ::std::vector<double>& saturation  () { return sat_   ; }
+        const ::std::vector<double>& faceflux    () const { return flux_; }
+        const ::std::vector<double>& saturation  () const { return sat_ ; }
 
-    const ::std::vector<double>& faceflux    () const { return flux_; }
-    const ::std::vector<double>& saturation  () const { return sat_ ; }
- 
-private:
-    ::std::vector<double> press_ ;
-    ::std::vector<double> fpress_;
-    ::std::vector<double> flux_  ;
-    ::std::vector<double> sat_   ;
-};
-class Rock {
-public:
-    Rock(::std::size_t nc, ::std::size_t dim)
-        : dim_ (dim           ),
-          perm_(nc * dim * dim),
-          poro_(nc            ) {}
+    private:
+        ::std::vector<double> press_ ;
+        ::std::vector<double> fpress_;
+        ::std::vector<double> flux_  ;
+        ::std::vector<double> sat_   ;
+    };
 
-    const ::std::vector<double>& perm() const { return perm_; }
-    const ::std::vector<double>& poro() const { return poro_; }
+    class Rock {
+    public:
+        Rock(::std::size_t nc, ::std::size_t dim)
+            : dim_ (dim           ),
+              perm_(nc * dim * dim),
+              poro_(nc            ) {}
 
-    void
-    perm_homogeneous(double k) {
-        setVector(0.0, perm_);
+        const ::std::vector<double>& perm() const { return perm_; }
+        const ::std::vector<double>& poro() const { return poro_; }
 
-        const ::std::size_t d2 = dim_ * dim_;
+        void
+        perm_homogeneous(double k) {
+            setVector(0.0, perm_);
 
-        for (::std::size_t c = 0, nc = poro_.size(); c < nc; ++c) {
-            for (::std::size_t i = 0; i < dim_; ++i) {
-                perm_[c*d2 + i*(dim_ + 1)] = k;
+            const ::std::size_t d2 = dim_ * dim_;
+
+            for (::std::size_t c = 0, nc = poro_.size(); c < nc; ++c) {
+                for (::std::size_t i = 0; i < dim_; ++i) {
+                    perm_[c*d2 + i*(dim_ + 1)] = k;
+                }
             }
         }
-    }
 
-    void
-    poro_homogeneous(double phi) {
-        setVector(phi, poro_);
-    }
-
-private:
-    void
-    setVector(double x, ::std::vector<double>& v) {
-        ::std::fill(v.begin(), v.end(), x);
-    }
-
-    ::std::size_t         dim_ ;
-    ::std::vector<double> perm_;
-    ::std::vector<double> poro_;
-};
-
-//template <class P>
-class TwophaseFluidWrapper {
-public:
-	TwophaseFluidWrapper(const Opm::ReservoirPropertyCapillary<3>& r)
-	        : r_(r)
-	{}
-	//TwophaseFluidWrapper(){}
-	//TwophaseFluidWrapper(TwophaseFluidWrapper){}
-
-    /*
-    void init(const Opm::ReservoirPropertyCapillary<3>& r)
-    {
-        r_ = r;
-    }
-    */
-
-    template <class Sat ,
-              class Mob ,
-              class DMob>
-    void
-    mobility(int c, const Sat& s, Mob& mob, DMob& dmob) const {
-        const double s1 = s[0];
-
-        r_.phaseMobilities     (c, s1, mob );
-        r_.phaseMobilitiesDeriv(c, s1, dmob);
-    }
-    template <class Sat ,
-              class PC ,
-              class DPC>
-    void
-    pc(int c, const Sat& s, PC& pc, DPC& dpc) const {
-    	const double s1 = s[0];
-    	pc = r_.capillaryPressure(c, s1);
-    	dpc= r_.capillaryPressureDeriv(c, s1);
-    }
-    double density(int p) const {
-        if (p == 0) {
-            return r_.densityFirstPhase();
-        } else {
-            return r_.densitySecondPhase();
+        void
+        poro_homogeneous(double phi) {
+            setVector(phi, poro_);
         }
-    }
 
-    double s_min(int c) const {
-        return r_.s_min(c);
-    }
-    double s_max(int c) const {
-    	return r_.s_max(c);
-    }
+    private:
+        void
+        setVector(double x, ::std::vector<double>& v) {
+            ::std::fill(v.begin(), v.end(), x);
+        }
 
+        ::std::size_t         dim_ ;
+        ::std::vector<double> perm_;
+        ::std::vector<double> poro_;
+    };
 
-private:
-    Opm::ReservoirPropertyCapillary<3> r_;
-};
-    
-class LinearSolverBICGSTAB {
-public:
-	typedef Dune::FieldVector<double, 1>    ScalarVectorBlockType;
-	typedef Dune::FieldMatrix<double, 1, 1> ScalarMatrixBlockType;
+    class TwophaseFluidWrapper {
+    public:
+        TwophaseFluidWrapper(const Opm::ReservoirPropertyCapillary<3>& r)
+            : r_(r)
+        {}
 
-	typedef Dune::BlockVector<ScalarVectorBlockType> ScalarBlockVector;
-	typedef Dune::BCRSMatrix <ScalarMatrixBlockType> ScalarBCRSMatrix;
+        template <class Sat ,
+                  class Mob ,
+                  class DMob>
+        void
+        mobility(int c, const Sat& s, Mob& mob, DMob& dmob) const {
+            const double s1 = s[0];
+
+            r_.phaseMobilities     (c, s1, mob );
+            r_.phaseMobilitiesDeriv(c, s1, dmob);
+        }
+
+        template <class Sat ,
+                  class PC ,
+                  class DPC>
+        void
+        pc(int c, const Sat& s, PC& pc, DPC& dpc) const {
+            const double s1 = s[0];
+            pc  = r_.capillaryPressure(c, s1);
+            dpc = r_.capillaryPressureDeriv(c, s1);
+        }
+
+        double density(int p) const {
+            if (p == 0) {
+                return r_.densityFirstPhase();
+            } else {
+                return r_.densitySecondPhase();
+            }
+        }
+
+        double s_min(int c) const {
+            return r_.s_min(c);
+        }
+
+        double s_max(int c) const {
+            return r_.s_max(c);
+        }
+
+    private:
+        Opm::ReservoirPropertyCapillary<3> r_;
+    };
+
+    class LinearSolverBICGSTAB {
+    public:
+        typedef Dune::FieldVector<double, 1>    ScalarVectorBlockType;
+        typedef Dune::FieldMatrix<double, 1, 1> ScalarMatrixBlockType;
+
+        typedef Dune::BlockVector<ScalarVectorBlockType> ScalarBlockVector;
+        typedef Dune::BCRSMatrix <ScalarMatrixBlockType> ScalarBCRSMatrix;
+
+        void
+        solve(const ScalarBCRSMatrix&  A,
+              const ScalarBlockVector& b,
+              ScalarBlockVector&       x)
+        {
+            Dune::MatrixAdapter<ScalarBCRSMatrix,
+                                ScalarBlockVector,
+                                ScalarBlockVector> opA(A);
+
+            Dune::SeqILU0<ScalarBCRSMatrix,
+                          ScalarBlockVector,
+                          ScalarBlockVector> precond(A, 1.0);
+
+            int maxit  = A.N();
+            double tol = 5.0e-7;
+            int verb   = 0;
+
+            Dune::BiCGSTABSolver<ScalarBlockVector>
+                solver(opA, precond, tol, maxit, verb);
+
+            ScalarBlockVector           bcpy(b);
+            Dune::InverseOperatorResult res;
+            solver.apply(x, bcpy, res);
+        }
+    };
+
+    class LinearSolverISTLAMG {
+    public:
+        LinearSolverISTLAMG()
+        {
+            Opm::parameter::ParameterGroup params;
+
+            params.insertParameter("linsolver_tolerance",
+                                   boost::lexical_cast<std::string>(5.0e-9));
+
+            params.insertParameter("linsoler_verbosity",
+                                   boost::lexical_cast<std::string>(1));
+
+            params.insertParameter("linsolver_type",
+                                   boost::lexical_cast<std::string>(1));
+
+            ls_.reset(new LinearSolverIstl(params));
+        }
+
+        void
+        solve(struct CSRMatrix* A,
+              const double*     b,
+              double*           x)
+        {
+            ls_->solve(A->m, A->nnz, A->ia, A->ja, A->sa, b, x);
+        }
+
+    private:
+        std::unique_ptr<Opm::LinearSolverIstl> ls_;
+    };
+
+    class TransportSource {
+    public:
+        TransportSource() : nsrc(0), pf(0) {}
+
+        int                   nsrc;
+        int                   pf;
+        ::std::vector< int  > cell;
+        ::std::vector<double> pressure;
+        ::std::vector<double> flux;
+        ::std::vector<double> saturation;
+        ::std::vector<double> periodic_cells;
+        ::std::vector<double> periodic_faces;
+    };
+
+    template <class Arr>
     void
-    solve(const ScalarBCRSMatrix&  A,
-          const ScalarBlockVector& b,
-          ScalarBlockVector&       x) {
-
-        Dune::MatrixAdapter<ScalarBCRSMatrix,
-                            ScalarBlockVector,
-                            ScalarBlockVector> opA(A);
-
-        Dune::SeqILU0<ScalarBCRSMatrix,
-                      ScalarBlockVector,
-                      ScalarBlockVector> precond(A, 1.0);
-
-        int maxit  = A.N();
-        double tol = 5.0e-7;
-        int verb   = 0;
-
-        Dune::BiCGSTABSolver<ScalarBlockVector>
-            solver(opA, precond, tol, maxit, verb);
-
-        ScalarBlockVector           bcpy(b);
-        Dune::InverseOperatorResult res;
-        solver.apply(x, bcpy, res);
-    }
-};
-
-class LinearSolverISTLAMG {
-public:
-    LinearSolverISTLAMG()
+    append_transport_source(int c, double p, double v, const Arr& s,
+                            TransportSource& src)
     {
-        Opm::parameter::ParameterGroup params;
-
-        params.insertParameter("linsolver_tolerance",
-                               boost::lexical_cast<std::string>(5.0e-9));
-
-        params.insertParameter("linsoler_verbosity",
-                               boost::lexical_cast<std::string>(1));
-
-        params.insertParameter("linsolver_type",
-                               boost::lexical_cast<std::string>(1));
-
-        ls_.reset(new LinearSolverIstl(params));
+        src.cell      .push_back(c);
+        src.pressure  .push_back(p);
+        src.flux      .push_back(v);
+        src.saturation.insert(src.saturation.end(),
+                              s.begin(), s.end());
+        ++src.nsrc;
     }
 
     void
-    solve(struct CSRMatrix* A,
-          const double*     b,
-          double*           x)
-    {
-        ls_->solve(A->m, A->nnz, A->ia, A->ja, A->sa, b, x);
-    }
+    compute_porevolume(const UnstructuredGrid* g,
+                       const Rock&             rock,
+                       std::vector<double>&    porevol);
+} // namespace Opm
 
-private:
-    std::unique_ptr<Opm::LinearSolverIstl> ls_;
-};
-
-class TransportSource {
-public:
-    TransportSource() : nsrc(0),pf(0) {}
-
-    int                   nsrc      ;
-    int                   pf      ;
-    ::std::vector< int  > cell      ;
-    ::std::vector<double> pressure  ;
-    ::std::vector<double> flux      ;
-    ::std::vector<double> saturation;
-    ::std::vector<double> periodic_cells;
-    ::std::vector<double> periodic_faces;
-};
-template <class Arr>
-void
-append_transport_source(int c, double p, double v, const Arr& s,
-                        TransportSource& src)
-{
-    src.cell      .push_back(c);
-    src.pressure  .push_back(p);
-    src.flux      .push_back(v);
-    src.saturation.insert(src.saturation.end(),
-                          s.begin(), s.end());
-    ++src.nsrc;
-}
-void
-compute_porevolume(const UnstructuredGrid*        g,
-                   const Rock&          rock,
-                   std::vector<double>& porevol)
-{
-    const ::std::vector<double>& poro = rock.poro();
-
-    assert (poro.size() == (::std::size_t)(g->number_of_cells));
-
-    porevol.resize(rock.poro().size());
-
-    ::std::transform(poro.begin(), poro.end(),
-                     g->cell_volumes,
-                     porevol.begin(),
-                     ::std::multiplies<double>());
-}
-}
-#endif // /OPENRS_IMPLICITTRANSPORTDEFS_HEADER
+#endif // OPENRS_IMPLICITTRANSPORTDEFS_HEADER

--- a/opm/upscaling/ParserAdditions.cpp
+++ b/opm/upscaling/ParserAdditions.cpp
@@ -1,0 +1,25 @@
+#include <opm/upscaling/ParserAdditions.hpp>
+
+#include <opm/json/JsonObject.hpp>
+
+#include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
+
+namespace {
+    void add_RHO(Opm::Parser& parser)
+    {
+        const auto rhoJsonData =
+R"~~({
+        "name"     : "RHO",
+        "sections" : [],
+        "data"     : {"value_type" : "DOUBLE" }
+}
+)~~";
+
+        parser.addParserKeyword(Json::JsonObject(rhoJsonData));
+    }
+} // Anonymous
+
+void Opm::addNonStandardUpscalingKeywords(Parser& parser)
+{
+    add_RHO(parser);
+}

--- a/opm/upscaling/ParserAdditions.cpp
+++ b/opm/upscaling/ParserAdditions.cpp
@@ -1,3 +1,22 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+
+  This file is part of The Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #include <opm/upscaling/ParserAdditions.hpp>
 
 #include <opm/json/JsonObject.hpp>

--- a/opm/upscaling/ParserAdditions.hpp
+++ b/opm/upscaling/ParserAdditions.hpp
@@ -21,27 +21,17 @@
 #define OPM_UPSCALING_PARSER_ADDITIONS_HPP
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
-#include <opm/json/JsonObject.hpp>
 
 namespace Opm {
 
-/*!
- * \brief This function registers the non-standard keywords used by
- *        opm-upscaling in a parser object.
- *
- * The name of this function is intentionally long and awkward. This
- * is to discourage its use unless it is *really* necessary!
- */
-inline void addNonStandardUpscalingKeywords(Opm::ParserPtr parser)
-{
-    const char *rhoJsonData =
-        "{\"name\" : \"RHO\", \"sections\" : [], \"data\" : {\"value_type\" : \"DOUBLE\" }}\n";
-
-    Json::JsonObject rhoJson(rhoJsonData);
-    parser->addParserKeyword( rhoJson );
-}
-
+    /*!
+     * \brief This function registers non-standard keywords used by
+     *        opm-upscaling in a parser object.
+     *
+     * The name of this function is intentionally long and awkward. This is
+     * to discourage its use unless it is *really* necessary!
+     */
+    void addNonStandardUpscalingKeywords(Parser& parser);
 }
 
 #endif

--- a/opm/upscaling/RelPermUtils.cpp
+++ b/opm/upscaling/RelPermUtils.cpp
@@ -652,10 +652,12 @@ double RelPermUpscaleHelper::tesselateGrid(Opm::DeckConstPtr deck)
     const auto linsolver_tolerance         = to_double(options["linsolver_tolerance"]);
     const auto linsolver_verbosity         = to_int   (options["linsolver_verbosity"]);
     const auto linsolver_type              = to_int   (options["linsolver_type"]);
+    const auto twodim_hack                 = false;
     const auto linsolver_maxit             = to_int   (options["linsolver_max_iterations"]);
     const auto smooth_steps                = to_int   (options["linsolver_smooth_steps"]);
     const auto linsolver_prolongate_factor = to_double(options["linsolver_prolongate_factor"]);
     const auto minPerm                     = to_double(options["minPerm"]);
+    const auto gravity                     = to_double(options["gravity"]);
 
     if (isMaster) {
         std::cout << "Tesselating grid... ";
@@ -667,8 +669,9 @@ double RelPermUpscaleHelper::tesselateGrid(Opm::DeckConstPtr deck)
 
     upscaler.init(deck, boundaryCondition,
                   unit::convert::from(minPerm, prefix::milli*unit::darcy),
-                  linsolver_tolerance, linsolver_verbosity, linsolver_type, false,
-                  linsolver_maxit, linsolver_prolongate_factor, smooth_steps);
+                  linsolver_tolerance, linsolver_verbosity, linsolver_type,
+                  twodim_hack, linsolver_maxit, linsolver_prolongate_factor,
+                  smooth_steps, gravity);
 
     const auto finish = clock();
     const auto timeused_tesselation =

--- a/opm/upscaling/RelPermUtils.cpp
+++ b/opm/upscaling/RelPermUtils.cpp
@@ -861,7 +861,7 @@ void RelPermUpscaleHelper::calculateMinMaxCapillaryPressure()
     // Sometimes, if Swmax=1 or Swir=0 in the input tables, the upscaled
     // values can be a little bit larger (within machine precision) and the
     // check below fails. Hence, check if these values are within the [0,1]
-    // interval within some precision (use linsolver_precision)
+    // interval within some precision (use linsolver_tolerance)
     if ((Swor > 1.0) && (Swor - linsolver_tolerance < 1.0)) {
         Swor = 1.0;
     }

--- a/opm/upscaling/RelPermUtils.cpp
+++ b/opm/upscaling/RelPermUtils.cpp
@@ -18,12 +18,37 @@
 */
 
 #include <config.h>
+
 #include <opm/upscaling/RelPermUtils.hpp>
+
+#include <opm/parser/eclipse/Parser/ParserKeywords.hpp>
+
+#include <opm/core/utility/Units.hpp>
+
 #include <algorithm>
-#include <iostream>
+#include <cmath>
+#include <cstdlib>
 #include <exception>
+#include <fstream>
+#include <iostream>
+#include <limits>
 #include <sstream>
-#include <cfloat>  // FOR DBL_MAX/DBL_MIN
+#include <stdexcept>
+#include <string>
+#include <tuple>
+
+namespace {
+    double to_double(const std::string& x)
+    {
+        return std::strtod(x.c_str(), nullptr);
+    }
+
+    int to_int(const std::string& x)
+    {
+        return static_cast<int>(std::strtol(x.c_str(), nullptr, 10));
+    }
+} // Anonymous
+
 
 namespace Opm {
 
@@ -64,28 +89,28 @@ void setVoigtValue(SinglePhaseUpscaler::permtensor_t& K, int voigt_idx, double v
 }
 
 RelPermUpscaleHelper::RelPermUpscaleHelper(int mpi_rank,
-                                           std::map<std::string,std::string>& options_) :
-    isMaster(mpi_rank == 0),
-    anisotropic_input(false),
-    permTensor(3,3,nullptr),
-    tesselatedCells(0),
-    permTensorInv(3,3,nullptr),
-    milliDarcyToSqMetre(Opm::unit::convert::to(1.0*Opm::prefix::milli*Opm::unit::darcy,
-                                               Opm::unit::square(Opm::unit::meter))),
-    options(options_)
+                                           std::map<std::string,std::string>& options_)
+    : isMaster         (mpi_rank == 0)
+    , anisotropic_input(false)
+    , permTensor       (3, 3, nullptr)
+    , tesselatedCells  (0)
+    , permTensorInv    (3, 3, nullptr)
+    , options          (options_)
 {
-    if (options["fluids"] == "ow" || options["fluids"] == "wo")
+    if (options["fluids"] == "ow" || options["fluids"] == "wo") {
         saturationstring = "Sw";
-    else if (options["fluids"] == "go" || options["fluids"] == "og")
+    }
+    else if (options["fluids"] == "go" || options["fluids"] == "og") {
         saturationstring = "Sg";
+    }
     else {
         std::stringstream str;
         str << "Fluidsystem " << options["fluids"] << " not valid (-fluids option). Should be ow or go";
         throw std::runtime_error(str.str());
     }
 
-    critRelpThresh = atof(options["critRelpermThresh"].c_str());
-    doEclipseCheck = (options["doEclipseCheck"] == "true");
+    critRelpThresh = to_double(options["critRelpermThresh"]);
+    doEclipseCheck = options["doEclipseCheck"] == "true";
 }
 
 void RelPermUpscaleHelper::collectResults()
@@ -207,14 +232,20 @@ std::vector<std::vector<double>> RelPermUpscaleHelper::getRelPerm(int phase) con
 void RelPermUpscaleHelper::upscaleSinglePhasePermeability()
 {
     if (isMaster) {
-        SinglePhaseUpscaler::permtensor_t cellperm(3,3,nullptr);
-        zero(cellperm);
-        const std::vector<int>& ecl_idx = upscaler.grid().globalCell();
-        for (unsigned int i = 0; i < ecl_idx.size(); ++i) {
-            unsigned int cell_idx = ecl_idx[i];
+        auto cellperm = SinglePhaseUpscaler::permtensor_t(3, 3, nullptr);
+
+        const auto& ecl_idx = upscaler.grid().globalCell();
+
+        for (decltype(ecl_idx.size())
+                 i = 0, n = ecl_idx.size(); i < n; ++i)
+        {
+            const auto cell_idx = ecl_idx[i];
+
             zero(cellperm);
+
             if (! anisotropic_input) {
-                double kval = std::max(perms[0][cell_idx], minSinglePhasePerm);
+                const auto kval = std::max(perms[0][cell_idx], minSinglePhasePerm);
+
                 cellperm(0,0) = kval;
                 cellperm(1,1) = kval;
                 cellperm(2,2) = kval;
@@ -224,145 +255,218 @@ void RelPermUpscaleHelper::upscaleSinglePhasePermeability()
                 cellperm(1,1) = std::max(minSinglePhasePerm, perms[1][cell_idx]);
                 cellperm(2,2) = std::max(minSinglePhasePerm, perms[2][cell_idx]);
             }
+
             upscaler.setPermeability(i, cellperm);
         }
-        permTensor = upscaler.upscaleSinglePhase();
+
+        permTensor    = upscaler.upscaleSinglePhase();
         permTensorInv = permTensor;
+
         invert(permTensorInv);
     }
 }
 
 void RelPermUpscaleHelper::sanityCheckInput(Opm::DeckConstPtr deck,
-                                            double minPerm,
-                                            double maxPerm,
-                                            double minPoro)
-
+                                            const double      minPerm,
+                                            const double      maxPerm,
+                                            const double      minPoro)
 {
-    // Check that we have the information we need from the eclipse file:
-    if (! (deck->hasKeyword("SPECGRID") && deck->hasKeyword("COORD") && deck->hasKeyword("ZCORN")
-           && deck->hasKeyword("PORO") && deck->hasKeyword("PERMX"))) {
-      throw std::runtime_error("Error: Did not find SPECGRID, COORD, ZCORN, PORO and PERMX in Eclipse file.");
-    }
+    {
+        using kw_poro   = ParserKeywords::PORO;
+        using kw_permx  = ParserKeywords::PERMX;
+        using kw_permy  = ParserKeywords::PERMY;
+        using kw_permz  = ParserKeywords::PERMZ;
+        using kw_satnum = ParserKeywords::SATNUM;
 
-    poros    = deck->getKeyword("PORO").getRawDoubleData();
-    perms[0] = deck->getKeyword("PERMX").getRawDoubleData();
-    zcorns   = deck->getKeyword("ZCORN").getRawDoubleData();
+        // Check that we have the information we need from the eclipse file:
+        if (! (deck->hasKeyword<kw_poro >() &&
+               deck->hasKeyword<kw_permx>()))
+        {
+            throw std::runtime_error("Error: Did not find complete set of "
+                                     "PORO and PERMX in ECLIPSE file.");
+        }
 
-    // Load anisotropic (only diagonal supported) input if present in grid
-    if (deck->hasKeyword("PERMY") && deck->hasKeyword("PERMZ")) {
-        anisotropic_input = true;
-        perms[1] = deck->getKeyword("PERMY").getRawDoubleData();
-        perms[2] = deck->getKeyword("PERMZ").getRawDoubleData();
-        if (isMaster)
-          std::cout << "Info: PERMY and PERMZ present, going into anisotropic input mode, no J-functions\n"
-                    << "      Options -relPermCurve and -jFunctionCurve is meaningless.\n";
-    }
+        poros    = deck->getKeyword<kw_poro >().getSIDoubleData();
+        perms[0] = deck->getKeyword<kw_permx>().getSIDoubleData();
 
+        EclipseGrid(deck).exportZCORN(zcorns);
 
-    /* Initialize a default satnums-vector with only "ones" (meaning only one rocktype) */
-    satnums.resize(poros.size(), 1);
+        // Load anisotropic (only diagonal supported) input if present in grid
+        if (deck->hasKeyword<kw_permy>() && deck->hasKeyword<kw_permz>()) {
+            anisotropic_input = true;
 
-    if (deck->hasKeyword("SATNUM")) {
-        satnums = deck->getKeyword("SATNUM").getIntData();
-    }
-    else {
-        if (isMaster)
-          std::cout << "SATNUM not found in input file, assuming only one rocktype" << std::endl;
-    }
+            perms[1] = deck->getKeyword<kw_permy>().getSIDoubleData();
+            perms[2] = deck->getKeyword<kw_permz>().getSIDoubleData();
 
-    /* Sanity check/fix on input for each cell:
-       - Check that SATNUM are set sensibly, that is => 0 and < 1000, error if not.
-       - Check that porosity is between 0 and 1, error if not.
-       Set to minPoro if zero or less than minPoro (due to pcmin/max computation)
-       - Check that permeability is zero or positive. Error if negative.
-       Set to minPerm if zero or less than minPerm.
-       - Check maximum number of SATNUM values (can be number of rock types present)
-    */
-    int cells_truncated_from_below_poro = 0;
-    int cells_truncated_from_below_permx = 0;
-    int cells_truncated_from_above_permx = 0;
-    auto it1 = std::find_if(satnums.begin(), satnums.end(), [](int a) { return a < 0; });
-    auto it2 = std::find_if(satnums.begin(), satnums.end(), [](int a) { return a > 1000;});
-    if (it1 != satnums.end() || it2 != satnums.end()) {
-        std::stringstream str;
-        str << "satnums[";
-        if (it1 == satnums.end())
-            str << it2-satnums.begin() << "] = " << *it2;
-        else
-            str << it1-satnums.begin() << "] = " << *it1;
-        str << ", not sane, quitting.";
-        throw std::runtime_error(str.str());
-    }
-
-    auto&& find_error_both  = [](double value) { return value < 0 || value > 1; };
-    auto it3 = std::find_if(poros.begin(), poros.end(), find_error_both);
-    if (it3 != poros.end()) {
-        std::stringstream str;
-        str << "poros[" << it3-poros.begin() <<"] = " << *it3 << ", not sane, quitting.";
-        throw std::runtime_error(str.str());
-    }
-    auto&& find_error_below = [](double value) { return value < 0; };
-    std::string name = "permx";
-    auto&& check_perm = [name,&find_error_below](const std::vector<double>& perm)
-                        {
-                            auto it = std::find_if(perm.begin(), perm.end(), find_error_below);
-                            if (it != perm.end()) {
-                                std::stringstream str;
-                                str << name <<"[" << it-perm.begin() <<"] = " << *it << ", not sane, quitting.";
-                                throw std::runtime_error(str.str());
-                            }
-                        };
-    check_perm(perms[0]);
-    if (anisotropic_input) {
-        name ="permy";
-        check_perm(perms[1]);
-        name ="permz";
-        check_perm(perms[2]);
-    }
-    std::transform(poros.begin(), poros.end(), poros.begin(),
-                   [minPoro,&cells_truncated_from_below_poro](double value)
-                   {
-                       if (value >= 0 && value < minPoro) { // Truncate porosity from below
-                           ++cells_truncated_from_below_poro;
-                           return minPoro;
-                       }
-                       return value;
-                   });
-
-    std::transform(perms[0].begin(), perms[0].end(), perms[0].begin(),
-                   [minPerm, maxPerm, &cells_truncated_from_below_permx,
-                    &cells_truncated_from_above_permx](double value)
-                   {
-                       if ((value >= 0) && (value < minPerm)) { // Truncate permeability from below
-                           ++cells_truncated_from_below_permx;
-                           return minPerm;
-                       }
-                       if (value > maxPerm) { // Truncate permeability from above
-                           ++cells_truncated_from_above_permx;
-                           return maxPerm;
-                       }
-
-                       return value;
-                   });
-
-    for (unsigned int i = 0; i < satnums.size(); ++i) {
-        // Explicitly handle "no rock" cells, set them to minimum perm and zero porosity.
-        if (satnums[i] == 0) {
-            perms[0][i] = minPerm;
-            if (anisotropic_input) {
-                perms[1][i] = minPerm;
-                perms[2][i] = minPerm;
+            if (isMaster) {
+                std::cout << "Info: PERMY and PERMZ present, going into "
+                          << "anisotropic input mode, no J-functions\n"
+                          << "  Options -relPermCurve and -jFunctionCurve "
+                          << "are meaningless.\n";
             }
-            poros[i] = 0; // zero poro is fine for these cells, as they are not
-            // used in pcmin/max computation.
+        }
+
+        if (deck->hasKeyword<kw_satnum>()) {
+            satnums = deck->getKeyword<kw_satnum>().getIntData();
+        }
+        else {
+            if (isMaster) {
+                std::cout << "SATNUM not found in input file, "
+                          << "assuming only one rocktype" << std::endl;
+            }
+
+            // Initialize a default satnums-vector with only "ones" (meaning
+            // only one rocktype).
+            satnums.assign(poros.size(), 1);
         }
     }
-    if (isMaster && cells_truncated_from_below_poro > 0)
-        std::cout << "Cells with truncated porosity: " << cells_truncated_from_below_poro << std::endl;
-    if (isMaster && cells_truncated_from_below_permx > 0)
-        std::cout << "Cells with permx truncated from below: " << cells_truncated_from_below_permx << std::endl;
-    if (isMaster && cells_truncated_from_above_permx > 0)
-        std::cout << "Cells with permx truncated from above: " << cells_truncated_from_above_permx << std::endl;
+
+    // Sanity check/fix on input for each cell:
+    //
+    // - Check that SATNUM are set sensibly, that is => 0 and < 1000, error
+    //   if not.
+    //
+    // - Check that porosity is between 0 and 1, error if not.  Set to
+    //   minPoro if zero or less than minPoro (due to pcmin/max computation)
+    //
+    // - Check that permeability is zero or positive. Error if negative.
+    //   Set to minPerm if zero or less than minPerm.
+    //
+    // - Check maximum number of SATNUM values (can be number of rock types
+    //   present)
+
+    {
+        auto it  = std::find_if(satnums.begin(), satnums.end(), [](int a) { return a < 0; });
+        auto it2 = std::find_if(satnums.begin(), satnums.end(), [](int a) { return a > 1000;});
+
+        if (it != satnums.end() || it2 != satnums.end()) {
+            std::stringstream str;
+            str << "satnums[";
+
+            if (it == satnums.end()) {
+                str << it2 - satnums.begin() << "] = " << *it2;
+            }
+            else {
+                str << it - satnums.begin() << "] = " << *it;
+            }
+
+            str << ", not sane, quitting.";
+
+            throw std::runtime_error(str.str());
+        }
+    }
+
+    {
+        auto it3 = std::find_if(poros.begin(), poros.end(),
+                                [](double value)
+                                {
+                                    return (value < 0) || (value > 1);
+                                });
+
+        if (it3 != poros.end()) {
+            std::stringstream str;
+
+            str << "poros[" << it3 - poros.begin() << "] = "
+                << *it3 << ", not sane, quitting.";
+
+            throw std::runtime_error(str.str());
+        }
+    }
+
+    {
+        auto name       = std::string("permx");
+        auto check_perm = [&name](const std::vector<double>& perm)
+        {
+            auto it = std::find_if(perm.begin(), perm.end(),
+                                   [](double value) { return value < 0; });
+
+            if (it != perm.end()) {
+                std::stringstream str;
+
+                str << name << "[" << it - perm.begin() << "] = "
+                    << *it << ", not sane, quitting.";
+
+                throw std::runtime_error(str.str());
+            }
+        };
+
+        check_perm(perms[0]);
+
+        if (anisotropic_input) {
+            name = "permy";   check_perm(perms[1]);
+            name = "permz";   check_perm(perms[2]);
+        }
+    }
+
+    auto cells_truncated_from_below_poro = 0;
+    {
+        for (auto& poro : poros) {
+            if ((! (poro < 0)) && (poro < minPoro)) {
+                poro = minPoro;
+
+                ++ cells_truncated_from_below_poro;
+            }
+        }
+    }
+
+    auto cells_truncated_from_below_permx = 0;
+    auto cells_truncated_from_above_permx = 0;
+    {
+        const auto lowPerm =
+            unit::convert::from(minPerm, prefix::milli*unit::darcy);
+
+        const auto highPerm =
+            unit::convert::from(maxPerm, prefix::milli*unit::darcy);
+
+        for (auto& kx : perms[0]) {
+            if ((! (kx < 0)) && (kx < lowPerm)) { // Truncate permeability from below
+                ++cells_truncated_from_below_permx;
+
+                kx = lowPerm;
+            }
+            else if (kx > highPerm) { // Truncate permeability from above
+                ++ cells_truncated_from_above_permx;
+
+                kx = highPerm;
+            }
+        }
+
+        for (decltype(satnums.size())
+                 i = 0, n = satnums.size(); i < n; ++i)
+        {
+            // Explicitly handle "no rock" cells, set them to minimum perm
+            // and zero porosity.
+            if (satnums[i] == 0) {
+                perms[0][i] = lowPerm;
+
+                if (anisotropic_input) {
+                    perms[1][i] = lowPerm;
+                    perms[2][i] = lowPerm;
+                }
+
+                // zero poro is fine for these cells, as they are not used
+                // in pcmin/max computation.
+                poros[i] = 0;
+            }
+        }
+    }
+
+    if (isMaster) {
+        if (cells_truncated_from_below_poro > 0) {
+            std::cout << "Cells with truncated porosity: "
+                      << cells_truncated_from_below_poro << std::endl;
+        }
+
+        if (cells_truncated_from_below_permx > 0) {
+            std::cout << "Cells with permx truncated from below: "
+                      << cells_truncated_from_below_permx << std::endl;
+        }
+
+        if (cells_truncated_from_above_permx > 0) {
+            std::cout << "Cells with permx truncated from above: "
+                      << cells_truncated_from_above_permx << std::endl;
+        }
+    }
 }
 
 bool RelPermUpscaleHelper::checkCurve(MonotCubicInterpolator& func)
@@ -424,165 +528,204 @@ void RelPermUpscaleHelper::setupBoundaryConditions()
 
 double RelPermUpscaleHelper::tesselateGrid(Opm::DeckConstPtr deck)
 {
-  double linsolver_tolerance = atof(options["linsolver_tolerance"].c_str());
-  int linsolver_verbosity = atoi(options["linsolver_verbosity"].c_str());
-  int linsolver_type = atoi(options["linsolver_type"].c_str());
-  int linsolver_maxit = atoi(options["linsolver_max_iterations"].c_str());
-  int smooth_steps = atoi(options["linsolver_smooth_steps"].c_str());
-  double linsolver_prolongate_factor = atof(options["linsolver_prolongate_factor"].c_str());
-  const double minPerm = atof(options["minPerm"].c_str());
+    const auto linsolver_tolerance         = to_double(options["linsolver_tolerance"]);
+    const auto linsolver_verbosity         = to_int   (options["linsolver_verbosity"]);
+    const auto linsolver_type              = to_int   (options["linsolver_type"]);
+    const auto linsolver_maxit             = to_int   (options["linsolver_max_iterations"]);
+    const auto smooth_steps                = to_int   (options["linsolver_smooth_steps"]);
+    const auto linsolver_prolongate_factor = to_double(options["linsolver_prolongate_factor"]);
+    const auto minPerm                     = to_double(options["minPerm"]);
 
-   if (isMaster)
-     std::cout << "Tesselating grid... ";
+    if (isMaster) {
+        std::cout << "Tesselating grid... ";
+    }
 
-   flush(std::cout);
-   clock_t start = clock();
+    std::flush(std::cout);
 
-  upscaler.init(deck, boundaryCondition,
-                Opm::unit::convert::from(minPerm, Opm::prefix::milli*Opm::unit::darcy),
-                linsolver_tolerance, linsolver_verbosity, linsolver_type, false,
-                linsolver_maxit, linsolver_prolongate_factor, smooth_steps);
+    const auto start = clock();
 
-   clock_t finish = clock();
-   double timeused_tesselation = (double(finish)-double(start))/CLOCKS_PER_SEC;
-   if (isMaster)
-     std::cout << " (" << timeused_tesselation <<" secs)" << std::endl;
+    upscaler.init(deck, boundaryCondition,
+                  unit::convert::from(minPerm, prefix::milli*unit::darcy),
+                  linsolver_tolerance, linsolver_verbosity, linsolver_type, false,
+                  linsolver_maxit, linsolver_prolongate_factor, smooth_steps);
 
-   return timeused_tesselation;
+    const auto finish = clock();
+    const auto timeused_tesselation =
+        (static_cast<double>(finish) - start) / CLOCKS_PER_SEC;
+
+    if (isMaster) {
+        std::cout << " (" << timeused_tesselation << " secs)" << std::endl;
+    }
+
+    return timeused_tesselation;
 }
 
 void RelPermUpscaleHelper::calculateCellPressureGradients(const std::array<int,3>& res)
 {
-    const double gravity            = atof(options["gravity"].c_str());
-    const double waterDensity       = atof(options["waterDensity"].c_str());
-    const double oilDensity         = atof(options["oilDensity"].c_str());
+    const auto gravity      = to_double(options["gravity"]);
+    const auto waterDensity = to_double(options["waterDensity"]);
+    const auto oilDensity   = to_double(options["oilDensity"]);
 
-    // height of model is calculated as the average of the z-values at the top layer
-    // This calculation makes assumption on the indexing of cells in the grid, going from bottom to top.
-    double modelHeight = 0;
-    for (size_t zIdx = (4 * res[0] * res[1] * (2*res[2]-1)); zIdx < zcorns.size(); ++zIdx)
-        modelHeight += zcorns[zIdx] / (4*res[0]*res[1]);
+    // height of model is calculated as the average of the z-values at the
+    // top layer.  This calculation makes assumption on the indexing of
+    // cells in the grid, going from bottom to top.
+    auto modelHeight = 0.0;
+    for (size_t zIdx = (4 * res[0] * res[1] * (2*res[2] - 1));
+         zIdx < zcorns.size(); ++zIdx)
+    {
+        modelHeight += zcorns[zIdx] / (4 * res[0] * res[1]);
+    }
 
     // We assume that the spatial units in the grid file is in centimetres,
     // so we divide by 100 to get to metres.
     modelHeight /= 100.0;
 
-    // Input water and oil density is given in g/cm3, we convert it to kg/m3 (SI)
-    // by multiplying with 1000.
-    double dRho = (waterDensity-oilDensity) * 1000; // SI unit (kg/m3)
+    // Input water and oil density is given in g/cm3, we convert it to kg/m3
+    // (SI) by multiplying with 1000.
+    const auto dRho = (waterDensity - oilDensity) * 1000; // SI unit (kg/m3)
 
     // Calculating difference in capillary pressure for all cells
     dP.resize(satnums.size(), 0);
-    for (size_t cellIdx = 0; cellIdx < satnums.size(); ++cellIdx) {
-        int i,j,k; // Position of cell in cell hierarchy
-        std::vector<int> zIndices(8,0); // 8 corners with 8 heights
-        int horIdx = (cellIdx+1) - int(std::floor(((double)(cellIdx+1))/((double)(res[0]*res[1]))))*res[0]*res[1]; // index in the corresponding horizon
-        if (horIdx == 0)
-            horIdx = res[0]*res[1];
+    for (decltype(satnums.size())
+             cellIdx = 0, n = satnums.size(); cellIdx < n; ++cellIdx)
+    {
+        // index in the corresponding horizon
+        auto horIdx = (cellIdx + 1) -
+            int(std::floor(((double)(cellIdx+1)) / ((double)(res[0] * res[1])))) * res[0]*res[1];
 
-        i = horIdx - int(std::floor(((double)horIdx)/((double)res[0])))*res[0];
+        if (horIdx == 0) {
+            horIdx = res[0] * res[1];
+        }
 
-        if (i == 0)
+        auto i = horIdx - int(std::floor(((double)horIdx) / ((double)res[0]))) * res[0];
+
+        if (i == 0) {
             i = res[0];
+        }
 
-        j = (horIdx-i)/res[0]+1;
-        k = ((cellIdx+1)-res[0]*(j-1)-1)/(res[0]*res[1])+1;
-        int zBegin = 8*res[0]*res[1]*(k-1); // indices of Z-values of bottom
-        int level2 = 4*res[0]*res[1]; // number of z-values in one horizon
-        zIndices[0] = zBegin + 4*res[0]*(j-1)+2*i-1;
-        zIndices[1] = zBegin + 4*res[0]*(j-1)+2*i;
-        zIndices[2] = zBegin + 2*res[0]*(2*j-1)+2*i;
-        zIndices[3] = zBegin + 2*res[0]*(2*j-1)+2*i-1;
-        zIndices[4] = zBegin + level2 + 4*res[0]*(j-1)+2*i-1;
-        zIndices[5] = zBegin + level2 + 4*res[0]*(j-1)+2*i;
-        zIndices[6] = zBegin + level2 + 2*res[0]*(2*j-1)+2*i;
-        zIndices[7] = zBegin + level2 + 2*res[0]*(2*j-1)+2*i-1;
+        const auto j = (horIdx - i) / res[0] + 1;
+        const auto k = ((cellIdx + 1) - res[0] * (j - 1) - 1) / (res[0] * res[1]) + 1;
 
-        double cellDepth = 0;
-        for (size_t corner = 0; corner < 8; ++corner)
+        const auto zBegin = 8 * res[0] * res[1] * (k-1); // indices of Z-values of bottom
+        const auto level2 = 4 * res[0] * res[1];         // number of z-values in one horizon
+
+        auto zIndices = std::vector<int>(8,0); // 8 corners with 8 heights
+
+        zIndices[0] = zBegin +          4*res[0]*(  j - 1) + 2*i - 1;
+        zIndices[1] = zBegin +          4*res[0]*(  j - 1) + 2*i;
+        zIndices[2] = zBegin +          2*res[0]*(2*j - 1) + 2*i;
+        zIndices[3] = zBegin +          2*res[0]*(2*j - 1) + 2*i - 1;
+
+        zIndices[4] = zBegin + level2 + 4*res[0]*(  j - 1) + 2*i - 1;
+        zIndices[5] = zBegin + level2 + 4*res[0]*(  j - 1) + 2*i;
+        zIndices[6] = zBegin + level2 + 2*res[0]*(2*j - 1) + 2*i;
+        zIndices[7] = zBegin + level2 + 2*res[0]*(2*j - 1) + 2*i - 1;
+
+        auto cellDepth = 0.0;
+        for (size_t corner = 0; corner < 8; ++corner) {
             cellDepth += zcorns[zIndices[corner]-1] / 8.0;
+        }
 
         // cellDepth is in cm, convert to m by dividing by 100
-        cellDepth /= 100.0;
-        dP[cellIdx] = dRho * gravity * (cellDepth-modelHeight/2.0);
+        cellDepth   /= 100.0;
+        dP[cellIdx]  = dRho * gravity * (cellDepth - modelHeight/2.0);
     }
 }
 
 void RelPermUpscaleHelper::calculateMinMaxCapillaryPressure()
 {
-    const double maxPermContrast = atof(options["maxPermContrast"].c_str());
-    const double minPerm         = atof(options["minPerm"].c_str());
-    const double gravity         = atof(options["gravity"].c_str());
-    double linsolver_tolerance   = atof(options["linsolver_tolerance"].c_str());
-    const bool includeGravity    = (fabs(gravity) > DBL_MIN); // true for non-zero gravity
+    const auto maxPermContrast     = to_double(options["maxPermContrast"]);
+    const auto minPerm             = to_double(options["minPerm"]);
+    const auto gravity             = to_double(options["gravity"]);
+    const auto linsolver_tolerance = to_double(options["linsolver_tolerance"]);
+    const auto includeGravity      =
+        (std::fabs(gravity) > std::numeric_limits<double>::min()); // true for non-zero gravity
 
-    if (maxPermContrast == 0)
+    if (maxPermContrast == 0) {
         throw std::runtime_error("Illegal contrast value");
-
-    std::vector<double> cellVolumes(satnums.size(), 0.0);
-    cellPoreVolumes.resize(satnums.size(), 0.0);
-
-    double dPmin = DBL_MAX, dPmax = -DBL_MAX;
-    if (!dP.empty()) {
-        dPmax = *std::max_element(dP.begin(), dP.end());
-        dPmin = *std::min_element(dP.begin(), dP.end());
     }
 
-    /* Find minimium and maximum capillary pressure values in each
-       cell, and use the global min/max as the two initial pressure
-       points for computations.
+    auto cellVolumes = std::vector<double>(satnums.size(), 0.0);
+    cellPoreVolumes.resize(satnums.size(), 0.0);
 
-       Also find max single-phase permeability, used to obey the
-       maxPermContrast option.
+    auto dPmin =  std::numeric_limits<double>::max();
+    auto dPmax = -std::numeric_limits<double>::max();
+    if (!dP.empty()) {
+        const auto m = std::minmax_element(dP.begin(), dP.end());
 
-       Also find properly upscaled saturation endpoints, these are
-       printed out to stdout for reference during computations, but will
-       automatically appear as the lowest and highest saturation points
-       in finished output.
-    */
-    Pcmax = -DBL_MAX, Pcmin = DBL_MAX;
-    double maxSinglePhasePerm = 0;
-    double Swirvolume = 0;
-    double Sworvolume = 0;
-    // cell_idx is the eclipse index.
-    const std::vector<int>& ecl_idx = upscaler.grid().globalCell();
-    Dune::CpGrid::Codim<0>::LeafIterator c = upscaler.grid().leafbegin<0>();
-    for (; c != upscaler.grid().leafend<0>(); ++c) {
-        unsigned int cell_idx = ecl_idx[c->index()];
+        dPmax = *m.second;
+        dPmin = *m.first;
+    }
+
+    // Find minimium and maximum capillary pressure values in each
+    // cell, and use the global min/max as the two initial pressure
+    // points for computations.
+    //
+    // Also find max single-phase permeability, used to obey the
+    // maxPermContrast option.
+    //
+    // Also find properly upscaled saturation endpoints, these are
+    // printed out to stdout for reference during computations, but will
+    // automatically appear as the lowest and highest saturation points
+    // in finished output.
+    Pcmin =  std::numeric_limits<double>::max();
+    Pcmax = -std::numeric_limits<double>::max();
+
+    auto maxSinglePhasePerm = 0.0;
+    auto Swirvolume         = 0.0;
+    auto Sworvolume         = 0.0;
+
+    const auto& ecl_idx = upscaler.grid().globalCell();
+
+    for (auto c  = upscaler.grid().leafbegin<0>(),
+             end = upscaler.grid().leafend<0>(); c != end; ++c)
+    {
+        const auto cell_idx = ecl_idx[c->index()];
+
         if (satnums[cell_idx] > 0) { // Satnum zero is "no rock"
 
-            cellVolumes[cell_idx] = c->geometry().volume();
+            cellVolumes    [cell_idx] = c->geometry().volume();
             cellPoreVolumes[cell_idx] = cellVolumes[cell_idx] * poros[cell_idx];
 
             double Pcmincandidate, Pcmaxcandidate, minSw, maxSw;
 
             if (! anisotropic_input) {
-                Pcmincandidate = InvJfunctions[int(satnums[cell_idx])-1].getMinimumX().first
-                    / sqrt(perms[0][cell_idx] * milliDarcyToSqMetre / poros[cell_idx]);
-                Pcmaxcandidate = InvJfunctions[int(satnums[cell_idx])-1].getMaximumX().first
-                    / sqrt(perms[0][cell_idx] * milliDarcyToSqMetre/poros[cell_idx]);
-                minSw = InvJfunctions[int(satnums[cell_idx])-1].getMinimumF().second;
-                maxSw = InvJfunctions[int(satnums[cell_idx])-1].getMaximumF().second;
+                const auto& invJ  = InvJfunctions[satnums[cell_idx] - 1];
+                const auto  kx    = perms[0][cell_idx];
+                const auto  denom = std::sqrt(kx / poros[cell_idx]);
+
+                Pcmincandidate = invJ.getMinimumX().first / denom;
+                Pcmaxcandidate = invJ.getMaximumX().first / denom;
+
+                minSw = invJ.getMinimumF().second;
+                maxSw = invJ.getMaximumF().second;
             }
             else { // anisotropic input, we do not to J-function scaling
-                Pcmincandidate = SwPcfunctions[int(satnums[cell_idx])-1].getMinimumX().first;
-                Pcmaxcandidate = SwPcfunctions[int(satnums[cell_idx])-1].getMaximumX().first;
+                const auto& satfunc = SwPcfunctions[satnums[cell_idx] - 1];
 
-                minSw = SwPcfunctions[int(satnums[cell_idx])-1].getMinimumF().second;
-                maxSw = SwPcfunctions[int(satnums[cell_idx])-1].getMaximumF().second;
+                Pcmincandidate = satfunc.getMinimumX().first;
+                Pcmaxcandidate = satfunc.getMaximumX().first;
+
+                minSw = satfunc.getMinimumF().second;
+                maxSw = satfunc.getMaximumF().second;
             }
+
             Pcmin = std::min(Pcmincandidate, Pcmin);
             Pcmax = std::max(Pcmaxcandidate, Pcmax);
 
-            maxSinglePhasePerm = std::max( maxSinglePhasePerm, perms[0][cell_idx]);
+            maxSinglePhasePerm = std::max(maxSinglePhasePerm, perms[0][cell_idx]);
 
             // Add irreducible water saturation volume
             Swirvolume += minSw * cellPoreVolumes[cell_idx];
             Sworvolume += maxSw * cellPoreVolumes[cell_idx];
         }
+
         ++tesselatedCells; // keep count.
     }
-    minSinglePhasePerm = std::max(maxSinglePhasePerm/maxPermContrast, minPerm);
+
+    minSinglePhasePerm =
+        std::max(maxSinglePhasePerm / maxPermContrast,
+                 unit::convert::from(minPerm, prefix::milli*unit::darcy));
 
     if (includeGravity) {
         Pcmin -= dPmax;
@@ -590,106 +733,139 @@ void RelPermUpscaleHelper::calculateMinMaxCapillaryPressure()
     }
 
     if (isMaster) {
-        std::cout << "Pcmin:    " << Pcmin << std::endl;
-        std::cout << "Pcmax:    " << Pcmax << std::endl;
+        std::cout << "Pcmin:    "
+                  << unit::convert::to(Pcmin, unit::barsa)
+                  << " [bar]\n"
+                  << "Pcmax:    "
+                  << unit::convert::to(Pcmax, unit::barsa)
+                  << " [bar]" << std::endl;
     }
 
-    if (Pcmin > Pcmax)
-        throw std::runtime_error("ERROR: No legal capillary pressures found for this system. Exiting...");
+    if (Pcmin > Pcmax) {
+        throw std::runtime_error("ERROR: No legal capillary pressures "
+                                 "found for this system. Exiting...");
+    }
 
     // Total porevolume and total volume -> upscaled porosity:
     poreVolume = std::accumulate(cellPoreVolumes.begin(), cellPoreVolumes.end(), 0.0);
-    volume = std::accumulate(cellVolumes.begin(), cellVolumes.end(), 0.0);
+    volume     = std::accumulate(cellVolumes.begin()    , cellVolumes.end()    , 0.0);
 
-    Swir = Swirvolume/poreVolume;
-    Swor = Sworvolume/poreVolume;
+    Swir = Swirvolume / poreVolume;
+    Swor = Sworvolume / poreVolume;
 
     if (isMaster) {
-        std::cout << "LF Pore volume:    " << poreVolume << std::endl;
-        std::cout << "LF Volume:         " << volume << std::endl;
-        std::cout << "Upscaled porosity: " << poreVolume/volume << std::endl;
-        std::cout << "Upscaled " << saturationstring << "ir:     " << Swir << std::endl;
-        std::cout << "Upscaled " << saturationstring << "max:    " << Swor << std::endl; //Swor=1-Swmax
-        std::cout << "Saturation points to be computed: " << points << std::endl;
+        std::cout << "LF Pore volume:    " << poreVolume << '\n'
+                  << "LF Volume:         " << volume << '\n'
+                  << "Upscaled porosity: " << (poreVolume / volume) << '\n'
+                  << "Upscaled "           << saturationstring << "ir:     " << Swir << '\n'
+                  << "Upscaled "           << saturationstring << "max:    " << Swor << '\n' //Swor=1-Swmax
+                  << "Saturation points to be computed: "
+                  << points << '\n';
     }
 
     // Sometimes, if Swmax=1 or Swir=0 in the input tables, the upscaled
-    // values can be a little bit larger (within machine precision) and
-    // the check below fails. Hence, check if these values are within the
-    // the [0 1] interval within some precision (use linsolver_precision)
-    if (Swor > 1.0 && Swor - linsolver_tolerance < 1.0) {
+    // values can be a little bit larger (within machine precision) and the
+    // check below fails. Hence, check if these values are within the [0,1]
+    // interval within some precision (use linsolver_precision)
+    if ((Swor > 1.0) && (Swor - linsolver_tolerance < 1.0)) {
         Swor = 1.0;
     }
-    if (Swir < 0.0 && Swir + linsolver_tolerance > 0.0) {
+
+    if ((Swir < 0.0) && (Swir + linsolver_tolerance > 0.0)) {
         Swir = 0.0;
     }
-    if (Swir < 0 || Swir > 1 || Swor < 0 || Swor > 1) {
+
+    if ((Swir < 0) || (Swir > 1) || (Swor < 0) || (Swor > 1)) {
         std::stringstream str;
-        str << "ERROR: " << saturationstring << "ir/" << saturationstring << "or unsensible. Check your input. Exiting";
+
+        str << "ERROR: "        // e.g., Swir/Swor nonsensical...
+            << saturationstring << "ir/"
+            << saturationstring << "or "
+            << "nonsensical. Check your input. Exiting";
+
         throw std::runtime_error(str.str());
     }
 }
 
 void RelPermUpscaleHelper::upscaleCapillaryPressure()
 {
-    const double saturationThreshold = atof(options["saturationThreshold"].c_str());
-    double largestSaturationInterval = Swor-Swir;
-    double Ptestvalue = Pcmax;
-    std::stringstream errstr;
-    const std::vector<int>& ecl_idx = upscaler.grid().globalCell();
+    const auto saturationThreshold =
+        to_double(options["saturationThreshold"]);
 
-    while (largestSaturationInterval > (Swor-Swir)/500.0) {
+    auto largestSaturationInterval = Swor - Swir;
+    auto Ptestvalue                = Pcmax;
+
+    std::stringstream errstr;
+
+    const auto& ecl_idx = upscaler.grid().globalCell();
+
+    while (largestSaturationInterval > (Swor - Swir) / 500.0) {
         if (Pcmax == Pcmin) {
-            // This is a dummy situation, we go through once and then
-            // we are finished (this will be triggered by zero permeability)
+            // This is a dummy situation, we go through once and then we are
+            // finished (this will be triggered by zero permeability)
             Ptestvalue = Pcmin;
             largestSaturationInterval = 0;
         }
         else if (WaterSaturationVsCapPressure.getSize() == 0) {
-            /* No data values previously computed */
+            // No data values previously computed
             Ptestvalue = Pcmax;
         }
         else if (WaterSaturationVsCapPressure.getSize() == 1) {
-            /* If only one point has been computed, it was for Pcmax. So now
-               do Pcmin */
+            // If only one point has been computed, it was for Pcmax. So now
+            // do Pcmin.
             Ptestvalue = Pcmin;
         }
         else {
-            /* Search for largest saturation interval in which there are no
-               computed saturation points (and estimate the capillary pressure
-               that will fall in the center of this saturation interval)
-               */
-            std::pair<double,double> SatDiff = WaterSaturationVsCapPressure.getMissingX();
-            Ptestvalue = SatDiff.first;
+            // Search for largest saturation interval in which there are no
+            // computed saturation points (and estimate the capillary
+            // pressure that will fall in the center of this saturation
+            // interval)
+            const auto& SatDiff = WaterSaturationVsCapPressure.getMissingX();
+
+            Ptestvalue                = SatDiff.first;
             largestSaturationInterval = SatDiff.second;
         }
 
         // Check for saneness of Ptestvalue:
         if (std::isnan(Ptestvalue) || std::isinf(Ptestvalue)) {
-            errstr << "ERROR: Ptestvalue was inf or nan" << std::endl;
+            errstr << "ERROR: Ptestvalue was inf or nan\n";
             break; // Jump out of while-loop, just print out the results
                    // up to now and exit the program
         }
 
-        double waterVolume = 0.0;
-        for (size_t i = 0; i < ecl_idx.size(); ++i) {
-            unsigned int cell_idx = ecl_idx[i];
+        auto waterVolume = 0.0;
+        for (decltype(ecl_idx.size())
+                 i = 0, n = ecl_idx.size(); i < n; ++i)
+        {
+            const auto cell_idx = ecl_idx[i];
+
             double waterSaturationCell = 0.0;
+
             if (satnums[cell_idx] > 0) { // handle "no rock" cells with satnum zero
-                double PtestvalueCell = Ptestvalue;
-                if (!dP.empty())
+                const auto ix = satnums[cell_idx] - 1;
+
+                auto PtestvalueCell = Ptestvalue;
+                if (!dP.empty()) {
                     PtestvalueCell -= dP[cell_idx];
+                }
 
                 if (!anisotropic_input) {
-                    double Jvalue = sqrt(perms[0][cell_idx] * milliDarcyToSqMetre / poros[cell_idx]) * PtestvalueCell;
-                    waterSaturationCell = InvJfunctions[int(satnums[cell_idx])-1].evaluate(Jvalue);
+                    const auto arg = perms[0][cell_idx] / poros[cell_idx];
+
+                    const auto Jvalue = std::sqrt(arg) * PtestvalueCell;
+
+                    waterSaturationCell = InvJfunctions[ix].evaluate(Jvalue);
                 }
-                else // anisotropic_input, then we do not do J-function-scaling
-                    waterSaturationCell = SwPcfunctions[int(satnums[cell_idx])-1].evaluate(PtestvalueCell);
+                else {
+                    // anisotropic_input, then we do not do J-function-scaling
+                    waterSaturationCell = SwPcfunctions[ix].evaluate(PtestvalueCell);
+                }
             }
-            waterVolume += waterSaturationCell  * cellPoreVolumes[cell_idx];
+
+            waterVolume += waterSaturationCell * cellPoreVolumes[cell_idx];
         }
-        WaterSaturationVsCapPressure.addPair(Ptestvalue, waterVolume/poreVolume);
+
+        WaterSaturationVsCapPressure.addPair(Ptestvalue, waterVolume / poreVolume);
     }
 
     // Now, it may happen that we have a large number of cells, and
@@ -701,42 +877,50 @@ void RelPermUpscaleHelper::upscaleCapillaryPressure()
 
     // Now we can also invert the upscaled water saturation
     // (it should be monotonic)
-    if (!WaterSaturationVsCapPressure.isStrictlyMonotone()) {
-        errstr <<  "Error: Upscaled water saturation not strictly monotone in capillary pressure." << std::endl
-               << "       Unphysical input data, exiting." << std::endl
-               << "       Trying to dump " << saturationstring << " vs Pc to file swvspc_debug.txt for inspection";
+    if (! WaterSaturationVsCapPressure.isStrictlyMonotone()) {
+        errstr << "Error: Upscaled water saturation not strictly "
+               << "monotone in capillary pressure.\n"
+               << "       Unphysical input data, exiting.\n"
+               << "       Trying to dump " << saturationstring
+               << " vs Pc to file swvspc_debug.txt for inspection";
+
         if (isMaster) {
-            std::ofstream outfile;
-            outfile.open("swvspc_debug.txt", std::ios::out | std::ios::trunc);
+            std::ofstream outfile("swvspc_debug.txt");
+
             outfile << "# Pc      " << saturationstring << std::endl;
             outfile << WaterSaturationVsCapPressure.toString();
-            outfile.close();
         }
+
         throw std::runtime_error(errstr.str());
     }
 }
 
 std::tuple<double, double>
-    RelPermUpscaleHelper::upscalePermeability(int mpi_rank)
+RelPermUpscaleHelper::upscalePermeability(int mpi_rank)
 {
-    const double minPerm = atof(options["minPerm"].c_str());
-    const double maxPermContrast = atof(options["maxPermContrast"].c_str());
+    const auto minPerm         = to_double(options["minPerm"]);
+    const auto maxPermContrast = to_double(options["maxPermContrast"]);
 
      // Put correct number of zeros in, just to be able to access RelPerm[index] later
     WaterSaturation.resize(points);
-    for (size_t i = 0; i < (upscaleBothPhases?2:1); ++i)
+    for (size_t i = 0; i < (upscaleBothPhases ? 2 : 1); ++i) {
         PhasePerm[i].resize(points, std::vector<double>(tensorElementCount));
-
-    // Make vector of capillary pressure points corresponding to uniformly distribued
-    // saturation points between Swor and Swir.
-    MonotCubicInterpolator CapPressureVsWaterSaturation(WaterSaturationVsCapPressure.get_fVector(),
-                                                        WaterSaturationVsCapPressure.get_xVector());
-
-    for (int pointidx = 1; pointidx <= points; ++pointidx) {
-        // pointidx=1 corresponds to Swir, pointidx=points to Swor.
-        double saturation = Swir + (Swor-Swir)/(points-1)*(pointidx-1);
-        pressurePoints.push_back(CapPressureVsWaterSaturation.evaluate(saturation));
     }
+
+    // Make vector of capillary pressure points corresponding to uniformly
+    // distribued saturation points between Swor and Swir.
+    {
+        auto CapPressureVsWaterSaturation =
+            MonotCubicInterpolator(WaterSaturationVsCapPressure.get_fVector(),
+                                   WaterSaturationVsCapPressure.get_xVector());
+
+        for (int pointidx = 1; pointidx <= points; ++pointidx) {
+            // pointidx=1 corresponds to Swir, pointidx=points to Swor.
+            double saturation = Swir + (Swor-Swir)/(points-1)*(pointidx-1);
+            pressurePoints.push_back(CapPressureVsWaterSaturation.evaluate(saturation));
+        }
+    }
+
     // Preserve max and min pressures
     pressurePoints.front() = Pcmax;
     pressurePoints.back()  = Pcmin;
@@ -744,110 +928,138 @@ std::tuple<double, double>
     // Fill with zeros initially (in case of non-mpi)
     node_vs_pressurepoint.resize(points);
 
-#if HAVE_MPI
+#if defined(HAVE_MPI) && HAVE_MPI
     // Distribute work load over mpi nodes.
     int mpi_nodecount;
     MPI_Comm_size(MPI_COMM_WORLD, &mpi_nodecount);
-    for (int idx=0; idx < points; ++idx) {
-        // Ensure master node gets equal or less work than the other nodes, since
-        // master node also computes single phase perm.
+
+    for (int idx = 0; idx < points; ++idx) {
+        // Ensure master node gets equal or less work than the other nodes,
+        // since master node also computes single phase perm.
         node_vs_pressurepoint[idx] = (mpi_nodecount-1) - idx % mpi_nodecount;
     }
 #endif
 
-    const std::vector<int>& ecl_idx = upscaler.grid().globalCell();
-    clock_t start_upscale_wallclock = clock();
+    const auto& ecl_idx = upscaler.grid().globalCell();
+
+    const auto start_upscale_wallclock = clock();
 
     double waterVolumeLF = 0.0;
-    // Now loop through the vector of capillary pressure points that
-    // this node should compute.
+
+    // Now loop through the vector of capillary pressure points that this
+    // node should compute.
     for (int pointidx = 0; pointidx < points; ++pointidx) {
 
         // Should "I" (mpi-wise) compute this pressure point?
         if (node_vs_pressurepoint[pointidx] == mpi_rank) {
 
-            double Ptestvalue = pressurePoints[pointidx];
+            const auto Ptestvalue = pressurePoints[pointidx];
 
             std::array<double,2> maxPhasePerm{{0.0, 0.0}};
             std::array<std::vector<double>,2> phasePermValues;
             std::array<std::vector<std::vector<double>>,2> phasePermValuesDiag;
             std::array<double,2> minPhasePerm;
             std::array<SinglePhaseUpscaler::permtensor_t,2> phasePermTensor;
-            for (size_t p = 0; p < (upscaleBothPhases?2:1); ++p) {
+
+            for (size_t p = 0; p < (upscaleBothPhases ? 2 : 1); ++p) {
                 waterVolumeLF = 0.0;
-                phasePermValues[p].resize(satnums.size());
+                phasePermValues    [p].resize(satnums.size());
                 phasePermValuesDiag[p].resize(satnums.size());
-                for (size_t i = 0; i < ecl_idx.size(); ++i) {
-                    unsigned int cell_idx = ecl_idx[i];
-                    double cellPhasePerm = minPerm;
-                    std::vector<double>  cellPhasePermDiag;
-                    cellPhasePermDiag.resize(3, minPerm);
+
+                for (decltype(ecl_idx.size())
+                         i = 0, n = ecl_idx.size(); i < n; ++i)
+                {
+                    const auto cell_idx = ecl_idx[i];
+                    double cellPhasePerm =
+                        unit::convert::from(minPerm, prefix::milli*unit::darcy);
+
+                    auto cellPhasePermDiag =
+                        std::vector<double>(3, cellPhasePerm);
+
+                    const auto ix = satnums[cell_idx] - 1;
+                    const auto kx = perms[0][cell_idx];
 
                     if (satnums[cell_idx] > 0) { // handle "no rock" cells with satnum zero
-                        double PtestvalueCell = Ptestvalue;
-                        if (!dP.empty())
+                        auto PtestvalueCell = Ptestvalue;
+                        if (!dP.empty()) {
                             PtestvalueCell -= dP[cell_idx];
+                        }
 
                         if (!anisotropic_input) {
-                            double Jvalue = sqrt(perms[0][cell_idx] * milliDarcyToSqMetre/poros[cell_idx]) * PtestvalueCell;
-                            double WaterSaturationCell
-                                = InvJfunctions[int(satnums[cell_idx])-1].evaluate(Jvalue);
+                            const auto Jvalue =
+                                std::sqrt(kx / poros[cell_idx]) * PtestvalueCell;
+
+                            const auto WaterSaturationCell =
+                                InvJfunctions[ix].evaluate(Jvalue);
+
                             waterVolumeLF += WaterSaturationCell * cellPoreVolumes[cell_idx];
 
                             // Compute cell relative permeability. We use a lower cutoff-value as we
                             // easily divide by zero here.  When water saturation is
                             // zero, we get 'inf', which is circumvented by the cutoff value.
                             cellPhasePerm =
-                                Krfunctions[0][p][int(satnums[cell_idx])-1].evaluate(WaterSaturationCell) *
-                                perms[0][cell_idx];
+                                Krfunctions[0][p][ix].evaluate(WaterSaturationCell) * kx;
                         }
                         else {
-                            double WaterSaturationCell = SwPcfunctions[int(satnums[cell_idx])-1].evaluate(PtestvalueCell);
+                            const auto WaterSaturationCell =
+                                SwPcfunctions[ix].evaluate(PtestvalueCell);
+
                             waterVolumeLF += WaterSaturationCell * cellPoreVolumes[cell_idx];
 
-                            cellPhasePermDiag[0] = Krfunctions[0][p][int(satnums[cell_idx])-1].evaluate(WaterSaturationCell) *
-                                perms[0][cell_idx];
-                            cellPhasePermDiag[1] = Krfunctions[1][p][int(satnums[cell_idx])-1].evaluate(WaterSaturationCell) *
-                                perms[1][cell_idx];
-                            cellPhasePermDiag[2] = Krfunctions[2][p][int(satnums[cell_idx])-1].evaluate(WaterSaturationCell) *
-                                perms[2][cell_idx];
+                            cellPhasePermDiag[0] =
+                                Krfunctions[0][p][ix].evaluate(WaterSaturationCell) * kx;
+
+                            cellPhasePermDiag[1] =
+                                Krfunctions[1][p][ix].evaluate(WaterSaturationCell) * perms[1][cell_idx];
+
+                            cellPhasePermDiag[2] =
+                                Krfunctions[2][p][ix].evaluate(WaterSaturationCell) * perms[2][cell_idx];
                         }
 
-                        phasePermValues[p][cell_idx] = cellPhasePerm;
+                        phasePermValues    [p][cell_idx] = cellPhasePerm;
                         phasePermValuesDiag[p][cell_idx] = cellPhasePermDiag;
+
                         maxPhasePerm[p] = std::max(maxPhasePerm[p], cellPhasePerm);
-                        maxPhasePerm[p] = std::max(maxPhasePerm[p], *std::max_element(cellPhasePermDiag.begin(),
-                                                                                      cellPhasePermDiag.end()));
+                        maxPhasePerm[p] = std::max(maxPhasePerm[p],
+                                                   *std::max_element(cellPhasePermDiag.begin(),
+                                                                     cellPhasePermDiag.end()));
                     }
                 }
 
-                // Now we can determine the smallest permitted permeability we can calculate for
-                // We have both a fixed bottom limit, as well as a possible higher limit determined
-                // by a maximum allowable permeability.
-                minPhasePerm[p] = std::max(maxPhasePerm[p]/maxPermContrast, minPerm);
+                // Now we can determine the smallest permitted permeability
+                // we can calculate for We have both a fixed bottom limit,
+                // as well as a possible higher limit determined by a
+                // maximum allowable permeability.
+                minPhasePerm[p] = std::max(maxPhasePerm[p] / maxPermContrast,
+                                           unit::convert::from(minPerm, prefix::milli*unit::darcy));
 
                 // Now remodel the phase permeabilities obeying minPhasePerm
-                SinglePhaseUpscaler::permtensor_t cellperm(3,3,nullptr);
-                zero(cellperm);
-                for (size_t i = 0; i < ecl_idx.size(); ++i) {
-                    unsigned int cell_idx = ecl_idx[i];
+                SinglePhaseUpscaler::permtensor_t cellperm(3, 3, nullptr);
+                for (decltype(ecl_idx.size())
+                         i = 0, n = ecl_idx.size(); i < n; ++i)
+                {
+                    const auto cell_idx = ecl_idx[i];
                     zero(cellperm);
+
                     if (!anisotropic_input) {
-                        double cellPhasePerm = std::max(minPhasePerm[p], phasePermValues[p][cell_idx]);
-                        double kval = std::max(minPhasePerm[p], cellPhasePerm);
+                        const auto cellPhasePerm =
+                            std::max(minPhasePerm[p], phasePermValues[p][cell_idx]);
+
+                        const auto kval = std::max(minPhasePerm[p], cellPhasePerm);
+
                         cellperm(0,0) = kval;
                         cellperm(1,1) = kval;
                         cellperm(2,2) = kval;
                     }
                     else { // anisotropic_input
                         // Truncate values lower than minPhasePerm upwards.
-                        phasePermValuesDiag[p][cell_idx][0] = std::max(minPhasePerm[p], phasePermValuesDiag[p][cell_idx][0]);
-                        phasePermValuesDiag[p][cell_idx][1] = std::max(minPhasePerm[p], phasePermValuesDiag[p][cell_idx][1]);
-                        phasePermValuesDiag[p][cell_idx][2] = std::max(minPhasePerm[p], phasePermValuesDiag[p][cell_idx][2]);
-                        cellperm(0,0) = phasePermValuesDiag[p][cell_idx][0];
-                        cellperm(1,1) = phasePermValuesDiag[p][cell_idx][1];
-                        cellperm(2,2) = phasePermValuesDiag[p][cell_idx][2];
+                        auto& k = phasePermValuesDiag[p][cell_idx];
+
+                        cellperm(0,0) = k[0] = std::max(minPhasePerm[p], k[0]);
+                        cellperm(1,1) = k[1] = std::max(minPhasePerm[p], k[1]);
+                        cellperm(2,2) = k[2] = std::max(minPhasePerm[p], k[2]);
                     }
+
                     upscaler.setPermeability(i, cellperm);
                 }
 
@@ -863,39 +1075,52 @@ std::tuple<double, double>
             // points are not perfectly uniformly distributed)
             WaterSaturation[pointidx] =  waterVolumeLF/poreVolume;
 
-
-#ifdef HAVE_MPI
+#if defined(HAVE_MPI) && HAVE_MPI
             std::cout << "Rank " << mpi_rank << ": ";
-#endif
+#endif  // HAVE_MPI
+
             std::cout << Ptestvalue << "\t" << WaterSaturation[pointidx];
+
             // Store and print phase-perm-result
             for (int voigtIdx=0; voigtIdx < tensorElementCount; ++voigtIdx) {
-                for (size_t p = 0; p < (upscaleBothPhases?2:1); ++p) {
-                    PhasePerm[p][pointidx][voigtIdx] = getVoigtValue(phasePermTensor[p], voigtIdx);
+                for (size_t p = 0; p < (upscaleBothPhases ? 2 : 1); ++p) {
+                    PhasePerm[p][pointidx][voigtIdx] =
+                        getVoigtValue(phasePermTensor[p], voigtIdx);
+
                     std::cout << "\t" << PhasePerm[p][pointidx][voigtIdx];
                 }
             }
-            std::cout << std::endl;
+
+            std::cout << '\n';
         }
     }
 
     clock_t finish_upscale_wallclock = clock();
-    double timeused_upscale_wallclock = (double(finish_upscale_wallclock)-double(start_upscale_wallclock))/CLOCKS_PER_SEC;
+    double timeused_upscale_wallclock =
+        (double(finish_upscale_wallclock) -
+         double(start_upscale_wallclock)) / CLOCKS_PER_SEC;
 
     collectResults();
 
     // Average time pr. upscaling point:
-#ifdef HAVE_MPI
+#if defined(HAVE_MPI) && HAVE_MPI
+
     // Sum the upscaling time used by all processes
     double timeused_total;
-    MPI_Reduce(&timeused_upscale_wallclock, &timeused_total, 1, MPI_DOUBLE,
-               MPI_SUM, 0, MPI_COMM_WORLD);
-    double avg_upscaling_time_pr_point = timeused_total/(double)points;
-#else
-    double avg_upscaling_time_pr_point = timeused_upscale_wallclock / (double)points;
-#endif
+    MPI_Reduce(&timeused_upscale_wallclock, &timeused_total, 1,
+               MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
 
-    return std::make_tuple(timeused_upscale_wallclock, avg_upscaling_time_pr_point);
+    const auto avg_upscaling_time_pr_point = timeused_total / points;
+
+#else
+
+    const auto avg_upscaling_time_pr_point =
+        timeused_upscale_wallclock / points;
+
+#endif  // HAVE_MPI
+
+    return std::make_tuple(timeused_upscale_wallclock,
+                           avg_upscaling_time_pr_point);
 }
 
 }

--- a/opm/upscaling/RelPermUtils.hpp
+++ b/opm/upscaling/RelPermUtils.hpp
@@ -115,9 +115,8 @@ namespace Opm {
       double tesselateGrid(Opm::DeckConstPtr deck);
 
       //! \brief Find cell center pressure gradient for every cell.
-      //! \param[in] res The number of cells in each direction.
       //! \details Uses the following options: gravity, waterDensity, oilDensity
-      void calculateCellPressureGradients(const std::array<int,3>& res);
+      void calculateCellPressureGradients();
 
       //! \brief Calculate minimum and maximum capillary pressures.
       //! \details Uses the following options: maxPermContrast, minPerm,

--- a/opm/upscaling/RelPermUtils.hpp
+++ b/opm/upscaling/RelPermUtils.hpp
@@ -24,12 +24,18 @@
 #ifndef OPM_UPSCALING_RELPERM_UTILS_HPP
 #define OPM_UPSCALING_RELPERM_UTILS_HPP
 
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+
 #include <opm/core/utility/MonotCubicInterpolator.hpp>
 
+#include <opm/upscaling/ParserAdditions.hpp>
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
 
 #include <array>
 #include <map>
+#include <memory>
 #include <tuple>
 #include <vector>
 
@@ -68,6 +74,18 @@ namespace Opm {
       double volume; //!< Total volume.
       double poreVolume; //!< Total pore volume.
       std::vector<double> pressurePoints; //!< Vector of capillary pressure points between Swor and Swir.
+
+      //! \brief Form Deck object from input file (ECLIPSE format)
+      //!
+      //! \tparam String String type for representing pathnames.  Typically
+      //! \code std::string \endcode or \code const char* \endcode.
+      //!
+      //! \param[in] eclipseFileName Name of input ECLIPSE file.
+      //!
+      //! \return Deck object resulting from parsing input file.
+      template <class String>
+      static std::shared_ptr<Deck>
+      parseEclipseFile(const String& eclipseFileName);
 
       //! \brief Default constructor.
       //! \param[in] mpi_rank Rank of this process (for parallel simulations).
@@ -160,6 +178,16 @@ namespace Opm {
       std::vector<double> dP; //!<  Cell center pressure gradients due to gravity effects.
       std::map<std::string,std::string>& options; //!< Reference to options structure.
   };
+
+  template <class String>
+  std::shared_ptr<Deck>
+  RelPermUpscaleHelper::parseEclipseFile(const String& eclipseFileName)
+  {
+    auto parser = Parser{};
+    addNonStandardUpscalingKeywords(parser);
+
+    return parser.parseFile(eclipseFileName, ParseContext{});
+  }
 }
 
-#endif
+#endif  // OPM_UPSCALING_RELPERM_UTILS_HPP

--- a/opm/upscaling/RelPermUtils.hpp
+++ b/opm/upscaling/RelPermUtils.hpp
@@ -25,8 +25,11 @@
 #define OPM_UPSCALING_RELPERM_UTILS_HPP
 
 #include <opm/core/utility/MonotCubicInterpolator.hpp>
+
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
+
 #include <array>
+#include <map>
 #include <tuple>
 #include <vector>
 
@@ -91,7 +94,9 @@ namespace Opm {
       //! \param[in] minPoro Minimum porosity.
       //! \details Throws error string.
       void sanityCheckInput(Opm::DeckConstPtr deck,
-                            double minPerm, double maxPerm, double minPoro);
+                            const double      minPerm,
+                            const double      maxPerm,
+                            const double      minPoro);
 
       //! \brief Check that input relperm curevs specify critical saturations.
       void checkCriticalSaturations();
@@ -128,6 +133,7 @@ namespace Opm {
       //! \details Uses the following options:  minPerm, maxPermContrast
       //! \return Tuple with (total time, time per point).
       std::tuple<double,double> upscalePermeability(int mpi_rank);
+
     private:
       //! \brief Perform critical saturation check for a single curve.
       //! \param[in,out] func Function to check for.
@@ -151,9 +157,6 @@ namespace Opm {
       double minSinglePhasePerm; //!< Minimum single phase permability value.
       std::vector<double> cellPoreVolumes; //!< Pore volume for each grid cell.
       MonotCubicInterpolator WaterSaturationVsCapPressure; //!< Water saturation as a function of capillary pressure.
-
-      // Reference: http://www.spe.org/spe-site/spe/spe/papers/authors/Metric_Standard.pdf
-      const double milliDarcyToSqMetre; //!< Conversion factor, multiply mD numbers with this to get m² numbers.
 
       std::vector<double> dP; //!<  Cell center pressure gradients due to gravity effects.
       std::map<std::string,std::string>& options; //!< Reference to options structure.

--- a/opm/upscaling/RelPermUtils.hpp
+++ b/opm/upscaling/RelPermUtils.hpp
@@ -175,7 +175,15 @@ namespace Opm {
       std::vector<double> cellPoreVolumes; //!< Pore volume for each grid cell.
       MonotCubicInterpolator WaterSaturationVsCapPressure; //!< Water saturation as a function of capillary pressure.
 
+#if defined(UNITTEST_TRESPASS_PRIVATE_PROPERTY_DP)
+    public: // Intrusive unit testing of calculcateCellPressureGradients()
+#endif // UNITTEST_TRESPASS_PRIVATE_PROPERTY_DP
       std::vector<double> dP; //!<  Cell center pressure gradients due to gravity effects.
+
+#if defined(UNITTEST_TRESPASS_PRIVATE_PROPERTY_DP)
+    private:
+#endif // UNITTEST_TRESPASS_PRIVATE_PROPERTY_DP
+
       std::map<std::string,std::string>& options; //!< Reference to options structure.
   };
 

--- a/opm/upscaling/UpscalerBase.hpp
+++ b/opm/upscaling/UpscalerBase.hpp
@@ -87,7 +87,8 @@ namespace Opm
                   bool twodim_hack = false,
                   int linsolver_maxit = 0,
                   double linsolver_prolongate_factor = 1.0,
-                  int linsolver_smooth_steps = 1);
+                  int linsolver_smooth_steps = 1,
+                  const double gravity = 0.0);
 
 	/// Access the grid.
 	const GridType& grid() const;
@@ -156,6 +157,7 @@ namespace Opm
 	int linsolver_verbosity_;
         int linsolver_type_;
         int linsolver_smooth_steps_;
+        double gravity_;
 
 	GridType grid_;
 	GridInterface ginterf_;

--- a/opm/upscaling/UpscalerBase.hpp
+++ b/opm/upscaling/UpscalerBase.hpp
@@ -35,11 +35,14 @@
 #ifndef OPM_UPSCALERBASE_HEADER
 #define OPM_UPSCALERBASE_HEADER
 
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
+
 #include <dune/grid/CpGrid.hpp>
+
 #include <opm/porsol/common/GridInterfaceEuler.hpp>
 #include <opm/porsol/common/BoundaryConditions.hpp>
-#include <opm/parser/eclipse/Deck/Deck.hpp>
 
 
 namespace Opm

--- a/opm/upscaling/UpscalerBase_impl.hpp
+++ b/opm/upscaling/UpscalerBase_impl.hpp
@@ -137,7 +137,8 @@ namespace Opm
                                            bool twodim_hack,
                                            int linsolver_maxit,
                                            double linsolver_prolongate_factor,
-                                           int linsolver_smooth_steps)
+                                           int linsolver_smooth_steps,
+                                           const double gravity)
     {
 	bctype_ = bctype;
 	residual_tolerance_ = residual_tolerance;
@@ -147,6 +148,8 @@ namespace Opm
          linsolver_prolongate_factor_ = linsolver_prolongate_factor;
         linsolver_smooth_steps_ = linsolver_smooth_steps;
 	twodim_hack_ = twodim_hack;
+        gravity_ = gravity;
+
 
 	// Faking some parameters depending on bc type.
         bool periodic_ext = (bctype_ == Periodic);
@@ -229,7 +232,7 @@ namespace Opm
 	std::vector<double> sat(num_cells, 1.0);
 	// Gravity.
 	Dune::FieldVector<double, 3> gravity(0.0);
-	// gravity[2] = -Dune::unit::gravity;
+	gravity[2] = gravity_;
 
 	permtensor_t upscaled_K(3, 3, (double*)0);
 	for (int pdd = 0; pdd < Dimension; ++pdd) {

--- a/tests/common/test_gravitypressure.cpp
+++ b/tests/common/test_gravitypressure.cpp
@@ -1,0 +1,486 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+
+  This file is part of The Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif  // HAVE_DYNAMIC_BOOST_TEST
+
+#define BOOST_TEST_MODULE UpscaleHelperGravityPressure
+
+// Enable intrusive unit-testing of private property
+//
+//   ::Opm::RelPermUpscaleHelper::dP
+//
+#define UNITTEST_TRESPASS_PRIVATE_PROPERTY_DP 1
+
+// This test fails in an MPI environment.
+#undef HAVE_MPI
+
+#include <opm/upscaling/RelPermUtils.hpp>
+#undef  UNITTEST_TRESPASS_PRIVATE_PROPERTY_DP
+
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+
+#include <opm/core/utility/Units.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <functional>
+#include <initializer_list>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/floating_point_comparison.hpp>
+
+namespace {                     // Case utilities
+    namespace GridInput {
+        namespace detail {
+            std::string RUNSPEC()
+            {
+                return R"~~(
+RUNSPEC
+
+DIMENS
+  1 1 10 /
+
+OIL
+WATER
+
+METRIC
+)~~";
+            }
+
+            // Note: Must be COORD + ZCORN because of details of
+            // implementation of Opm::UpscalerBase--notably the
+            // representation of the rock properties.
+            std::string GRID()
+            {
+                return R"~~(
+GRID
+
+COORD
+  0 0 0   0 0 0
+  1 0 0   1 0 0
+  0 1 0   0 1 0
+  1 1 0   1 1 0
+/
+
+ZCORN
+  4*0.0
+  4*0.1
+
+  4*0.1
+  4*0.2
+
+  4*0.2
+  4*0.3
+
+  4*0.3
+  4*0.4
+
+  4*0.4
+  4*0.5
+
+  4*0.5
+  4*0.6
+
+  4*0.6
+  4*0.7
+
+  4*0.7
+  4*0.8
+
+  4*0.8
+  4*0.9
+
+  4*0.9
+  4*1.0
+/
+
+PERMX
+  10*100
+/
+
+PERMY
+  10*100
+/
+
+PERMZ
+  10*10
+/
+
+PORO
+  10*0.3
+/
+)~~";
+            }
+        } // detail
+
+        std::string basic()
+        {
+            return detail::RUNSPEC() + detail::GRID();
+        }
+    } // GridInput
+
+    namespace Options
+    {
+        using Opt = std::map<std::string, std::string>;
+
+        namespace detail {
+            Opt tesselateBasic()
+            {
+                return
+                {
+                    {"linsolver_tolerance",       "1e-12"},
+                    {"linsolver_verbosity",           "0"},
+                    {"linsolver_type",                "3"},
+                    {"linsolver_max_iterations",      "0"},
+                    {"linsolver_smooth_steps",        "1"},
+                    {"linsolver_prolongate_factor", "1.0"},
+                    {"minPerm",                   "1e-12"}, // mD
+                };
+            }
+
+            Opt fluidSystem()
+            {
+                return
+                {
+                    { "fluids", "ow" },
+                };
+            }
+
+            Opt boundaryCondition()
+            {
+                return
+                {
+                    { "bc", "fixed" },
+                };
+            }
+
+            Opt gravityOn()
+            {
+                return
+                {
+                    { "gravity", "10.0" },
+                };
+            }
+
+            Opt gravityOff()
+            {
+                return
+                {
+                    { "gravity", "Zero" },
+                };
+            }
+
+            Opt gravityEquator()
+            {
+                return
+                {
+                    { "gravity", "9.80665" },
+                };
+            }
+
+            Opt densityNormal()
+            {
+                return
+                {
+                    { "waterDensity", "1.0" }, // g/cm3
+                    { "oilDensity"  , "0.8" }, // g/cm3
+                };
+            }
+
+            Opt densityWrong()
+            {
+                // String->double conversion internally effected by
+                // std::strtod() which returns zero (0.0) when unable to
+                // convert an input string.  No error checking at time of
+                // writing.
+                //
+                // These options therefore behave as if set to "0.0".
+                return
+                {
+                    { "waterDensity", "One" }, // g/cm3
+                    { "oilDensity"  , "Zero Point Eight" }, // g/cm3
+                };
+            }
+
+            Opt mergeOptions(Opt&&                      into,
+                             std::initializer_list<Opt> others)
+            {
+                for (const auto& other : others) {
+                    into.insert(other.begin(), other.end());
+                }
+
+                return into;
+            }
+        } // detail
+
+        Opt baseCase()
+        {
+            return detail::mergeOptions(detail::tesselateBasic(),
+                                        { detail::boundaryCondition(),
+                                          detail::fluidSystem(),
+                                          detail::gravityOn(),
+                                          detail::densityNormal() });
+        }
+
+        Opt noGravity()
+        {
+            return detail::mergeOptions(detail::tesselateBasic(),
+                                        { detail::boundaryCondition(),
+                                          detail::fluidSystem(),
+                                          detail::gravityOff(),
+                                          detail::densityNormal() });
+        }
+
+        Opt noGravityWrong()
+        {
+            return detail::mergeOptions(detail::tesselateBasic(),
+                                        { detail::boundaryCondition(),
+                                          detail::fluidSystem(),
+                                          detail::gravityOn(),
+                                          detail::densityWrong() });
+        }
+
+        Opt equator()
+        {
+            return detail::mergeOptions(detail::tesselateBasic(),
+                                        { detail::boundaryCondition(),
+                                          detail::fluidSystem(),
+                                          detail::gravityEquator(),
+                                          detail::densityNormal() });
+        }
+    } // Options
+
+    namespace TestCase
+    {
+        namespace Results
+        {
+            struct Computed
+            {
+                explicit Computed(std::vector<double>&& x);
+
+                std::vector<double> data;
+            };
+
+            struct Expected
+            {
+                explicit Expected(std::vector<double>&& x);
+
+                std::vector<double> data;
+            };
+
+            Computed::Computed(std::vector<double>&& x)
+                : data(std::move(x))
+            {}
+
+            Expected::Expected(std::vector<double>&& x)
+                : data(std::move(x))
+            {}
+
+            void compare(const Computed& computed,
+                         const Expected& expected)
+            {
+                const auto& c = computed.data;
+                const auto& e = expected.data;
+
+                BOOST_REQUIRE_EQUAL(c.size(), e.size());
+
+                for (decltype(c.size())
+                         i = 0, n = c.size(); i < n; ++i)
+                {
+                    BOOST_CHECK_CLOSE(c[i], e[i], 100.0e-6);
+                }
+            }
+        } // Results
+
+        namespace Expect
+        {
+            namespace detail
+            {
+                std::vector<double>::size_type
+                numCells()
+                {
+                    return 10;
+                }
+
+                double offset()
+                {
+                    return 5.0;
+                }
+
+                double g10()
+                {
+                    return 10.0;
+                }
+
+                double gEquator()
+                {
+                    return 9.80665;
+                }
+
+                double dRho()
+                {
+                    using namespace Opm;
+
+                    return unit::convert::
+                        from(1.0 - 0.8,
+                             prefix::milli*unit::kilogram
+                             / unit::cubic(prefix::centi*unit::meter));
+                }
+
+                std::vector<double>
+                gravityPressure(const double grav)
+                {
+                    auto dp = std::vector<double>(numCells(), 0.0);
+
+                    if (std::abs(grav) > 0.0) {
+                        const auto off  = offset();
+                        const auto drho = dRho();
+
+                        decltype(dp.size()) i = 0;
+
+                        for (auto& x : dp) {
+                            x = grav * drho * ((i + 0.5 - off) / numCells());
+
+                            ++i;
+                        }
+                    }
+
+                    return dp;
+                }
+            } // detail
+
+            std::vector<double> noGravity()
+            {
+                return detail::gravityPressure(0.0);
+            }
+
+            std::vector<double> gravity10()
+            {
+                return detail::gravityPressure(detail::g10());
+            }
+
+            std::vector<double> gravityEquator()
+            {
+                return detail::gravityPressure(detail::gEquator());
+            }
+        } // Expect
+
+        namespace Compute
+        {
+            std::vector<double>
+            modelDP(const std::string& input,
+                    Options::Opt&      options)
+            {
+                // We're NOT master (rank == 0) in this context.
+                //
+                // This is to suppress informational/diagnostic output from
+                // RelPermUpscaleHelper during grid construction (i.e., when
+                // calling tesselateGrid()).
+                const auto mpi_rank = 1;
+
+                Opm::RelPermUpscaleHelper helper{mpi_rank, options};
+                {
+                    auto parse = Opm::Parser{};
+                    auto deck  = parse.parseString(input, Opm::ParseContext{});
+
+                    const auto minPerm = 0;      // mD
+                    const auto maxPerm = 10.0e3; // mD
+                    const auto minPoro = 0.1;
+
+                    // Note: sanityCheckInput() extracts and stores private
+                    // copies of ZCORN and PERMX from the 'deck'.
+                    //
+                    // This function *must* be called before tesselateGrid().
+                    helper.sanityCheckInput(deck, minPerm, maxPerm, minPoro);
+
+                    // Function tesselateGrid() cannot be called unless the
+                    // upscaler's boundary conditions are well defined.
+                    helper.setupBoundaryConditions();
+
+                    helper.tesselateGrid(deck);
+                }
+
+                helper.calculateCellPressureGradients();
+
+                // Note: 'private' member of RelPermUpscaleHelper.
+                return helper.dP;
+            }
+        } // Compute
+
+        void run(std::function<std::string()>         input,
+                 std::function<Options::Opt()>        options,
+                 std::function<std::vector<double>()> expect)
+        {
+            auto computed = std::vector<double>{};
+            {
+                auto opt = options(); // Live for duration of modelDP().
+                computed = Compute::modelDP(input(), opt);
+            }
+
+            Results::compare(Results::Computed{std::move(computed)},
+                             Results::Expected{expect()});
+        }
+    } // TestCase
+} // Anonymous
+
+// =====================================================================
+// Actual test suite below
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE()
+
+BOOST_AUTO_TEST_CASE (BaseCase)
+{
+    TestCase::run(GridInput::basic,
+                  Options::baseCase,
+                  TestCase::Expect::gravity10);
+}
+
+BOOST_AUTO_TEST_CASE (NoGravity)
+{
+    TestCase::run(GridInput::basic,
+                  Options::noGravity,
+                  TestCase::Expect::noGravity);
+}
+
+BOOST_AUTO_TEST_CASE (NoGravityWrong)
+{
+    TestCase::run(GridInput::basic,
+                  Options::noGravityWrong,
+                  TestCase::Expect::noGravity);
+}
+
+BOOST_AUTO_TEST_CASE (GravityEquator)
+{
+    TestCase::run(GridInput::basic,
+                  Options::equator,
+                  TestCase::Expect::gravityEquator);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/compare_upscaling_results.cpp
+++ b/tests/compare_upscaling_results.cpp
@@ -30,6 +30,7 @@ using namespace Opm;
 
 typedef FullMatrix<double, OwnData, COrdering> Matrix;
 
+namespace {
 
 /// @brief
 ///    Read result file and store results in a matrix.
@@ -111,6 +112,7 @@ bool matrixAlmostEqual(Matrix refSoln, Matrix newSoln, double tol) {
     return true;
 }
 
+} // namespace anonymous
 
 /// @brief
 ///    Tests if two result files are equal


### PR DESCRIPTION
This PR is a first cut at supporting effects of gravity when doing steady-state relative permeability upscaling.  Most of the work is guaranteeing a consistent treatment of the units of measurements that are employed within the `RelPermUtils.cpp` as well as refactoring of `examples/upscale_relperm.cpp`.