### PR TITLE
Fix mpi in gravity pressure test

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -8,6 +8,7 @@
 
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
+export OMPI_MCA_plm_rsh_agent=/bin/false
 
 %:
 	dh $@ 

--- a/tests/common/test_gravitypressure.cpp
+++ b/tests/common/test_gravitypressure.cpp
@@ -31,8 +31,13 @@
 //
 #define UNITTEST_TRESPASS_PRIVATE_PROPERTY_DP 1
 
-// This test fails in an MPI environment.
-#undef HAVE_MPI
+#include <dune/common/version.hh>
+
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 3)
+#include <dune/common/parallel/mpihelper.hh>
+#else
+#include <dune/common/mpihelper.hh>
+#endif
 
 #include <opm/upscaling/RelPermUtils.hpp>
 #undef  UNITTEST_TRESPASS_PRIVATE_PROPERTY_DP
@@ -403,6 +408,10 @@ PORO
                 // RelPermUpscaleHelper during grid construction (i.e., when
                 // calling tesselateGrid()).
                 const auto mpi_rank = 1;
+
+                int m_argc = boost::unit_test::framework::master_test_suite().argc;
+                char** m_argv = boost::unit_test::framework::master_test_suite().argv;
+                Dune::MPIHelper& mhelper = Dune::MPIHelper::instance(m_argc, m_argv);
 
                 Opm::RelPermUpscaleHelper helper{mpi_rank, options};
                 {


### PR DESCRIPTION
In the interest of getting rc1 out the door, I pushed packages with these fixes in them.

The packaging fix was just something I forgot in opm-upscaling and had in the rest of the modules.
As for the second fix I paste the commit message;


> fixed: instance a MPI helper in gravity pressure test
    
>    the #undef HAVE_MPI trick does not work because we are linking
>    against MPI code already compiled in a library.