### PR TITLE
tests/runtest.sh now respects exit code

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 INPUT_DATA_PATH="$1"
 RESULT_PATH="$2"


### PR DESCRIPTION
Adding flag `set -e` to `runtest.sh` makes `runtest.sh` fail on first error.

* runtest runs `$BINPATH/$EXE_NAME $TEST_ARGS` ... 
* ... and then `$BINPATH/compare_upscaling_results [args] `

If the first command throws (exits with error code > 0), the latter command would still return with 0.  This led the tests to pass despite uncaught errors occurred.