### PR TITLE
usage of static_assert

### DIFF
--- a/opm/elasticity/elasticity_preconditioners.hpp
+++ b/opm/elasticity/elasticity_preconditioners.hpp
@@ -42,7 +42,7 @@ typedef Dune::UMFPack<Matrix> LUSolver;
 #elif defined(HAVE_SUPERLU)
 typedef Dune::SuperLU<Matrix> LUSolver;
 #else
-static_assert("Enable either SuperLU or UMFPACK");
+static_assert(false, "Enable either SuperLU or UMFPACK");
 #endif
 
 //! \brief A linear operator


### PR DESCRIPTION
It is my understanding that the macro `static_assert` has signature `(bool, str)`.  This PR is a one-line fix of the use of `static_assert` in the event that the user does not have UMFPACK nor SuperLU.

The full patch is:
```diff
-static_assert("Enable either SuperLU or UMFPACK");
+static_assert(false, "Enable either SuperLU or UMFPACK");
```

See also [Static assertion at cppreference](http://en.cppreference.com/w/cpp/language/static_assert).