### PR TITLE
Improved error message on file not found error

### DIFF
--- a/tests/compareUpscaling.cpp
+++ b/tests/compareUpscaling.cpp
@@ -31,8 +31,9 @@ void readData(const char* fileName, std::vector<double> &dataVec){
     std::ifstream inFile (fileName, std::ifstream::in);
     std::string line, value; 
     if(inFile.fail()){
-	std::cout << "For filename: " << fileName << std::endl; 
-	OPM_THROW(std::runtime_error, "Could not open file.");
+        std::string fname = fileName;
+        std::cout << "Could not open file " + fname << std::endl;
+        OPM_THROW(std::runtime_error, "Could not open file " + fname);
     }
     while(std::getline(inFile, line)){
 	std::stringstream ss(line);


### PR DESCRIPTION
This PR is an extremely minor fixup (3 lines diff) for error messages when tests fail to find some file.  Previously, the error message was

```
For filename: <some_file_name>
```

Now we output the filename of the file that fails to be opened:

```
Could not open file <some_file_name>
```