### PR TITLE
adapt to the removal of the unit system of opm-core

### DIFF
--- a/benchmarks/upscale_relperm_benchmark.cpp
+++ b/benchmarks/upscale_relperm_benchmark.cpp
@@ -112,7 +112,7 @@
 
 #include <opm/upscaling/RelPermUtils.hpp>
 
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/material/common/Unused.hpp>
 
 // Choose model:

--- a/examples/cpchop.cpp
+++ b/examples/cpchop.cpp
@@ -32,7 +32,7 @@
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/core/utility/MonotCubicInterpolator.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <opm/output/eclipse/CornerpointChopper.hpp>
 #include <opm/output/eclipse/EclipseGridInspector.hpp>

--- a/examples/cpchop_depthtrend.cpp
+++ b/examples/cpchop_depthtrend.cpp
@@ -31,7 +31,7 @@
 
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <opm/output/eclipse/CornerpointChopper.hpp>
 

--- a/examples/cpregularize.cpp
+++ b/examples/cpregularize.cpp
@@ -51,7 +51,7 @@
 
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <opm/output/eclipse/CornerpointChopper.hpp>
 #include <opm/output/eclipse/EclipseGridInspector.hpp>

--- a/examples/exp_variogram.cpp
+++ b/examples/exp_variogram.cpp
@@ -42,7 +42,7 @@
 
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <opm/output/eclipse/CornerpointChopper.hpp>
 

--- a/examples/grdecldips.cpp
+++ b/examples/grdecldips.cpp
@@ -32,7 +32,7 @@
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <opm/output/eclipse/CornerpointChopper.hpp>
 #include <opm/output/eclipse/EclipseGridInspector.hpp>

--- a/examples/known_answer_test.cpp
+++ b/examples/known_answer_test.cpp
@@ -52,7 +52,7 @@
 
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/core/utility/StopWatch.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <dune/grid/CpGrid.hpp>
 

--- a/examples/mimetic_aniso_solver_test.cpp
+++ b/examples/mimetic_aniso_solver_test.cpp
@@ -55,7 +55,7 @@
 
 #include <dune/grid/CpGrid.hpp>
 
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 
 #include <opm/output/eclipse/EclipseGridInspector.hpp>

--- a/examples/mimetic_periodic_test.cpp
+++ b/examples/mimetic_periodic_test.cpp
@@ -35,7 +35,7 @@
 
 #include "config.h"
 
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 
 #include <dune/grid/CpGrid.hpp>

--- a/examples/mimetic_solver_test.cpp
+++ b/examples/mimetic_solver_test.cpp
@@ -60,7 +60,7 @@
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <dune/grid/CpGrid.hpp>
 

--- a/examples/upscale_cap.cpp
+++ b/examples/upscale_cap.cpp
@@ -66,7 +66,7 @@
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/core/utility/MonotCubicInterpolator.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <opm/upscaling/RelPermUtils.hpp>
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>

--- a/examples/upscale_cond.cpp
+++ b/examples/upscale_cond.cpp
@@ -63,7 +63,7 @@
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/core/utility/MonotCubicInterpolator.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <opm/upscaling/RelPermUtils.hpp>
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>

--- a/examples/upscale_relperm.cpp
+++ b/examples/upscale_relperm.cpp
@@ -70,7 +70,7 @@
 
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <opm/upscaling/RelPermUtils.hpp>
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>

--- a/examples/upscale_singlephase.cpp
+++ b/examples/upscale_singlephase.cpp
@@ -34,7 +34,7 @@
 
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <opm/upscaling/SinglePhaseUpscaler.hpp>
 

--- a/opm/porsol/blackoil/BlackoilInitialization.hpp
+++ b/opm/porsol/blackoil/BlackoilInitialization.hpp
@@ -22,7 +22,7 @@
 
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/common/ErrorMacros.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <iostream>
 

--- a/opm/porsol/blackoil/BlackoilSimulator.hpp
+++ b/opm/porsol/blackoil/BlackoilSimulator.hpp
@@ -31,7 +31,7 @@
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 #include <opm/porsol/common/BoundaryConditions.hpp>
 #include <opm/porsol/blackoil/BlackoilInitialization.hpp>

--- a/opm/porsol/blackoil/fluid/BlackoilPVT.cpp
+++ b/opm/porsol/blackoil/fluid/BlackoilPVT.cpp
@@ -20,7 +20,7 @@
 #include "config.h"
 
 #include "BlackoilPVT.hpp"
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 #include "MiscibilityDead.hpp"
 #include "MiscibilityLiveOil.hpp"
 #include "MiscibilityLiveGas.hpp"

--- a/opm/porsol/common/ReservoirPropertyCommon.hpp
+++ b/opm/porsol/common/ReservoirPropertyCommon.hpp
@@ -36,7 +36,7 @@
 #ifndef OPENRS_RESERVOIRPROPERTYCOMMON_HEADER
 #define OPENRS_RESERVOIRPROPERTYCOMMON_HEADER
 
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/porsol/common/Matrix.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>

--- a/opm/porsol/common/SimulatorBase.hpp
+++ b/opm/porsol/common/SimulatorBase.hpp
@@ -41,7 +41,7 @@
 
 #include <opm/core/utility/SparseVector.hpp>
 #include <opm/core/utility/SparseTable.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <dune/grid/common/Volumes.hpp>
 #include <dune/grid/CpGrid.hpp>

--- a/opm/porsol/common/setupBoundaryConditions.hpp
+++ b/opm/porsol/common/setupBoundaryConditions.hpp
@@ -37,7 +37,7 @@
 #define OPENRS_SETUPBOUNDARYCONDITIONS_HEADER
 
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/porsol/common/BoundaryConditions.hpp>
 #include <opm/porsol/common/PeriodicHelpers.hpp>
 

--- a/opm/porsol/common/setupGridAndProps.hpp
+++ b/opm/porsol/common/setupGridAndProps.hpp
@@ -37,7 +37,7 @@
 #define OPM_SETUPGRIDANDPROPS_HEADER
 
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 #include <dune/grid/CpGrid.hpp>
 #include <opm/porsol/common/ReservoirPropertyCapillary.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/opm/porsol/euler/EulerUpstreamImplicit_impl.hpp
+++ b/opm/porsol/euler/EulerUpstreamImplicit_impl.hpp
@@ -39,7 +39,7 @@
 
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/core/utility/Average.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 #include <dune/grid/common/Volumes.hpp>
 #include <opm/core/utility/StopWatch.hpp>
 #include <opm/porsol/common/ImplicitTransportDefs.hpp>

--- a/opm/porsol/euler/EulerUpstreamResidual_impl.hpp
+++ b/opm/porsol/euler/EulerUpstreamResidual_impl.hpp
@@ -45,7 +45,7 @@
 
 //#include <opm/common/ErrorMacros.hpp>
 #include <opm/core/utility/Average.hpp>
-//#include <opm/core/utility/Units.hpp>
+//#include <opm/parser/eclipse/Units/Units.hpp>
 //#include <dune/grid/common/Volumes.hpp>
 
 #include <opm/porsol/common/Matrix.hpp>

--- a/opm/porsol/euler/EulerUpstream_impl.hpp
+++ b/opm/porsol/euler/EulerUpstream_impl.hpp
@@ -41,7 +41,7 @@
 
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/core/utility/Average.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 #include <dune/grid/common/Volumes.hpp>
 #include <opm/porsol/euler/CflCalculator.hpp>
 #include <opm/core/utility/StopWatch.hpp>

--- a/opm/porsol/euler/ImplicitCapillarity_impl.hpp
+++ b/opm/porsol/euler/ImplicitCapillarity_impl.hpp
@@ -38,7 +38,7 @@
 
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/core/utility/Average.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/core/utility/RootFinders.hpp>
 #include <opm/core/utility/StopWatch.hpp>
 #include <dune/grid/common/Volumes.hpp>

--- a/opm/upscaling/RelPermUtils.cpp
+++ b/opm/upscaling/RelPermUtils.cpp
@@ -23,7 +23,7 @@
 
 #include <opm/parser/eclipse/Parser/ParserKeywords.hpp>
 
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <algorithm>
 #include <cmath>

--- a/opm/upscaling/SteadyStateUpscalerImplicit_impl.hpp
+++ b/opm/upscaling/SteadyStateUpscalerImplicit_impl.hpp
@@ -42,7 +42,7 @@
 #include <opm/porsol/common/SimulatorUtilities.hpp>
 #include <opm/porsol/common/ReservoirPropertyFixedMobility.hpp>
 #include <opm/porsol/euler/MatchSaturatedVolumeFunctor.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/output/eclipse/writeECLData.hpp>
 #include <opm/core/utility/miscUtilities.hpp>
 #include <algorithm>

--- a/opm/upscaling/SteadyStateUpscalerManager.hpp
+++ b/opm/upscaling/SteadyStateUpscalerManager.hpp
@@ -39,7 +39,7 @@
 
 #include <opm/upscaling/SteadyStateUpscaler.hpp>
 #include <opm/upscaling/UpscalingTraits.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/core/utility/SparseTable.hpp>
 #include <cmath>
 #include <fstream>

--- a/opm/upscaling/SteadyStateUpscalerManagerImplicit.hpp
+++ b/opm/upscaling/SteadyStateUpscalerManagerImplicit.hpp
@@ -39,7 +39,7 @@
 
 #include <opm/upscaling/SteadyStateUpscalerImplicit.hpp>
 #include <opm/upscaling/UpscalingTraits.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/core/utility/SparseTable.hpp>
 #include <cmath>
 #include <fstream>

--- a/opm/upscaling/SteadyStateUpscaler_impl.hpp
+++ b/opm/upscaling/SteadyStateUpscaler_impl.hpp
@@ -41,7 +41,7 @@
 #include <opm/porsol/common/MatrixInverse.hpp>
 #include <opm/porsol/common/SimulatorUtilities.hpp>
 #include <opm/porsol/common/ReservoirPropertyFixedMobility.hpp>
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 #include <algorithm>
 #include <iostream>
 

--- a/tests/common/test_gravitypressure.cpp
+++ b/tests/common/test_gravitypressure.cpp
@@ -46,7 +46,7 @@
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
-#include <opm/core/utility/Units.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <cmath>
 #include <cstddef>


### PR DESCRIPTION
the one which is in opm-parser is now a drop-in replacement.

see OPM/opm-parser#936 for details.