### PR TITLE
Require z-clipping for both linear and periodic bc types.

### DIFF
--- a/opm/porsol/common/setupGridAndProps.hpp
+++ b/opm/porsol/common/setupGridAndProps.hpp
@@ -89,10 +89,11 @@ namespace Opm
                 std::cerr << "****** Warning: z_tolerance parameter is obsolete, use PINCH in deck input instead\n";
             }
             bool periodic_extension = param.getDefault<bool>("periodic_extension", false);
+            bool clip_z = param.getDefault<bool>("clip_z", false);
             bool turn_normals = param.getDefault<bool>("turn_normals", false);
             {
                 Opm::EclipseGrid inputGrid(deck);
-                grid.processEclipseFormat(inputGrid, periodic_extension, turn_normals);
+                grid.processEclipseFormat(inputGrid, periodic_extension, turn_normals, clip_z);
             }
             // Save EGRID file in case we are writing ECL output.
             if (param.getDefault("output_ecl", false)) {

--- a/opm/upscaling/UpscalerBase_impl.hpp
+++ b/opm/upscaling/UpscalerBase_impl.hpp
@@ -101,6 +101,9 @@ namespace Opm
             if (!temp_param.has("use_unique_boundary_ids")) {
                 temp_param.insertParameter("use_unique_boundary_ids", "true");
             }
+            if (!temp_param.has("clip_z")) {
+                temp_param.insertParameter("clip_z", "true");
+            }
         }
         if (bctype_ == Periodic) {
             if (!temp_param.has("periodic_extension")) {
@@ -154,7 +157,7 @@ namespace Opm
 	// Faking some parameters depending on bc type.
         bool periodic_ext = (bctype_ == Periodic);
         bool turn_normals = false;
-        bool clip_z = (bctype_ == Periodic);
+        bool clip_z = (bctype_ == Linear || bctype_ == Periodic);
         bool unique_bids = (bctype_ == Linear || bctype_ == Periodic);
         std::string rock_list("no_list");
 	setupGridAndPropsEclipse(deck,


### PR DESCRIPTION
This fixes a bug related to upscaling grids that are not "shoe-box" shaped, for such cases the grid must be z-clipped if either linear or periodic boundary conditions are to be used for the upscaling. (For the linear bc case this could be relaxed but that would require a bit of rewriting.) The fix includes:
 - For the setup path used by the single-phase upscaling code: now also set clip_z to true for Linear bcs.
 - For the setup path used by the steady-state upscaling code: set clip_z to true for Linear *and* Periodic bcs (note that this path did not even have this logic present for Periodic bcs before).

I intend to self-merge this when green.