### PR TITLE
dune.module: add opm-parser and opm-core to the dependencies

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -10,4 +10,4 @@ Label: 2017.10-pre
 Maintainer: arne.morten.kvarving@sintef.no
 MaintainerName: Arne Morten Kvarving
 Url: http://opm-project.org
-Depends: dune-common (>= 2.4) dune-grid (>= 2.4) dune-istl (>= 2.4) opm-grid opm-common
+Depends: dune-common (>= 2.4) dune-grid (>= 2.4) dune-istl (>= 2.4) opm-parser opm-common opm-grid opm-core


### PR DESCRIPTION
since the dependency order of opm-grid and opm-core has been reversed, opm-grid does not imply opm-core anymore but vice-versa.

for opm-parser, it is IMO good style to specify all dependencies explicitly.

please merge this together with OPM/opm-common#261 .