### PR TITLE
Require Dune 2.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,20 +83,6 @@ macro (config_hook)
 		HAVE_UMFPACK
 		HAVE_SUPERLU
 		)
-	# check unversioned CpGrid api change
-	check_cxx_source_compiles("
-	#include <dune/grid/CpGrid.hpp>
-
-	int main()
-	{
-		Dune::CpGrid grid;
-		grid.readEclipseFormat(\"foo\", 1.0e-3, false, false);
-		return 0;
-	}
-	" HAVE_OLD_CPGRID_API)
-	if (HAVE_OLD_CPGRID_API)
-		add_definitions(-DHAVE_OLD_CPGRID_API)
-	endif()
 endmacro (config_hook)
 
 macro (prereqs_hook)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ include (CMakeLists_files.cmake)
 
 macro (config_hook)
 	opm_need_version_of ("dune-common")
+	opm_need_version_of ("dune-geometry")
 	opm_need_version_of ("dune-istl")
 	list (APPEND ${project}_CONFIG_IMPL_VARS
 		HAVE_LAPACK

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,47 +106,6 @@ macro (sources_hook)
 endmacro (sources_hook)
 
 macro (files_hook)
-	find_dune_version ("dune" "istl")
-	if((DUNE_ISTL_VERSION_MAJOR GREATER 2) OR
-		(DUNE_ISTL_VERSION_MAJOR EQUAL 2 AND DUNE_ISTL_VERSION_MINOR GREATER 2))
-		list (APPEND MAIN_SOURCE_FILES
-			opm/elasticity/boundarygrid.cpp
-			opm/elasticity/elasticity_preconditioners.cpp
-			opm/elasticity/material.cpp
-			opm/elasticity/materials.cpp
-			opm/elasticity/matrixops.cpp
-			opm/elasticity/meshcolorizer.cpp
-			opm/elasticity/mpc.cpp
-			)
-		list(APPEND PROGRAM_SOURCE_FILES examples/upscale_elasticity.cpp)
-		list (APPEND EXAMPLE_SOURCE_FILES examples/upscale_elasticity.cpp)
-		list (APPEND TEST_DATA_FILES
-			tests/input_data/reference_solutions/upscale_elasticity_mpc_EightCells.txt
-			tests/input_data/reference_solutions/upscale_elasticity_mortar_EightCells.txt
-		)
-		list (APPEND PUBLIC_HEADER_FILES
-			opm/elasticity/applier.hpp
-			opm/elasticity/asmhandler.hpp
-			opm/elasticity/asmhandler_impl.hpp
-			opm/elasticity/boundarygrid.hh
-			opm/elasticity/elasticity.hpp
-			opm/elasticity/elasticity_impl.hpp
-			opm/elasticity/elasticity_preconditioners.hpp
-			opm/elasticity/elasticity_upscale.hpp
-			opm/elasticity/elasticity_upscale_impl.hpp
-			opm/elasticity/logutils.hpp
-			opm/elasticity/material.hh
-			opm/elasticity/materials.hh
-			opm/elasticity/matrixops.hpp
-			opm/elasticity/mortar_evaluator.hpp
-			opm/elasticity/mortar_schur.hpp
-			opm/elasticity/mortar_schur_precond.hpp
-			opm/elasticity/mortar_utils.hpp
-			opm/elasticity/mpc.hh
-			opm/elasticity/shapefunctions.hpp
-			opm/elasticity/uzawa_solver.hpp
-			)
-	endif()
 endmacro (files_hook)
 
 macro (fortran_hook)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -47,8 +47,15 @@ list(APPEND MAIN_SOURCE_FILES
 	opm/porsol/euler/ImplicitCapillarity.cpp
 	opm/upscaling/ParserAdditions.cpp
 	opm/upscaling/RelPermUtils.cpp
-        opm/upscaling/initCPGrid.cpp
-        opm/upscaling/writeECLData.cpp
+ 	opm/upscaling/initCPGrid.cpp
+ 	opm/upscaling/writeECLData.cpp
+ 	opm/elasticity/boundarygrid.cpp
+ 	opm/elasticity/elasticity_preconditioners.cpp
+ 	opm/elasticity/material.cpp
+ 	opm/elasticity/materials.cpp
+ 	opm/elasticity/matrixops.cpp
+ 	opm/elasticity/meshcolorizer.cpp
+ 	opm/elasticity/mpc.cpp
 	)
 
 # originally generated with the command:
@@ -76,6 +83,8 @@ list (APPEND TEST_DATA_FILES
 	tests/input_data/reference_solutions/upscale_relperm_BCl_pts30_surfTens11_stone1_stone1_EightCells.txt
 	tests/input_data/reference_solutions/upscale_relperm_BCf_pts30_surfTens45_stone1_stone1_EightCells.txt
 	tests/input_data/reference_solutions/upscale_relperm_BCf_pts30_surfTens11_stoneAniso_stoneAniso_27cellsAniso.txt
+  tests/input_data/reference_solutions/upscale_elasticity_mpc_EightCells.txt
+  tests/input_data/reference_solutions/upscale_elasticity_mortar_EightCells.txt
   tests/input_data/reference_solutions/upscale_elasticity_mpc_EightCells.txt
   tests/input_data/reference_solutions/upscale_elasticity_mortar_EightCells.txt
 	)
@@ -109,6 +118,7 @@ list (APPEND EXAMPLE_SOURCE_FILES
 	examples/upscale_relpermvisc.cpp
 	examples/upscale_singlephase.cpp
 	examples/upscale_steadystate_implicit.cpp
+ 	examples/upscale_elasticity.cpp
 	tests/compareUpscaling.cpp
 	)
 
@@ -144,6 +154,7 @@ list (APPEND PROGRAM_SOURCE_FILES
 	examples/upscale_relpermvisc.cpp
 	examples/upscale_singlephase.cpp
 	examples/upscale_steadystate_implicit.cpp
+ 	examples/upscale_elasticity.cpp
 	)
 
 # originally generated with the command:
@@ -221,6 +232,26 @@ list (APPEND PUBLIC_HEADER_FILES
 	opm/upscaling/UpscalerBase_impl.hpp
 	opm/upscaling/UpscalingTraits.hpp
 	opm/upscaling/CornerpointChopper.hpp
-        opm/upscaling/initCPGrid.hpp
-        opm/upscaling/writeECLData.hpp
+  	opm/upscaling/initCPGrid.hpp
+ 	opm/upscaling/writeECLData.hpp
+ 	opm/elasticity/applier.hpp
+ 	opm/elasticity/asmhandler.hpp
+ 	opm/elasticity/asmhandler_impl.hpp
+ 	opm/elasticity/boundarygrid.hh
+ 	opm/elasticity/elasticity.hpp
+ 	opm/elasticity/elasticity_impl.hpp
+ 	opm/elasticity/elasticity_preconditioners.hpp
+ 	opm/elasticity/elasticity_upscale.hpp
+ 	opm/elasticity/elasticity_upscale_impl.hpp
+ 	opm/elasticity/logutils.hpp
+ 	opm/elasticity/material.hh
+ 	opm/elasticity/materials.hh
+ 	opm/elasticity/matrixops.hpp
+ 	opm/elasticity/mortar_evaluator.hpp
+ 	opm/elasticity/mortar_schur.hpp
+ 	opm/elasticity/mortar_schur_precond.hpp
+ 	opm/elasticity/mortar_utils.hpp
+ 	opm/elasticity/mpc.hh
+ 	opm/elasticity/shapefunctions.hpp
+ 	opm/elasticity/uzawa_solver.hpp
 	)

--- a/dune.module
+++ b/dune.module
@@ -10,4 +10,4 @@ Label: 2017.10-pre
 Maintainer: arne.morten.kvarving@sintef.no
 MaintainerName: Arne Morten Kvarving
 Url: http://opm-project.org
-Depends: dune-common dune-grid dune-istl opm-grid opm-common
+Depends: dune-common (>= 2.4) dune-grid (>= 2.4) dune-istl (>= 2.4) opm-grid opm-common

--- a/examples/upscale_elasticity.cpp
+++ b/examples/upscale_elasticity.cpp
@@ -496,11 +496,10 @@ try
       return runAMG<AMG2Level>(p);
     else
       return runAMG<AMG1>(p);
+  } catch (Dune::Exception &e) {
+    std::cerr << "Dune reported error: " << e << std::endl;
   } catch (const std::exception &e) {
     throw e;
-  }
-  catch (Dune::Exception &e) {
-    std::cerr << "Dune reported error: " << e << std::endl;
   }
   catch (...) {
     std::cerr << "Unknown exception thrown!" << std::endl;

--- a/opm/elasticity/boundarygrid.hh
+++ b/opm/elasticity/boundarygrid.hh
@@ -336,7 +336,7 @@ class HexGeometry<2, cdim, GridImp>
       for (int i=0;i<4;++i) {
         typename GridImp::LeafGridView::template Codim<3>::Iterator it=start;
         for (; it != itend; ++it) {
-          if (mapper.map(*it) == q.v[i].i)
+          if (mapper.index(*it) == q.v[i].i)
             break;
         }
         BoundaryGrid::extract(c[i],it->geometry().corner(0),dir);

--- a/opm/elasticity/boundarygrid.hh
+++ b/opm/elasticity/boundarygrid.hh
@@ -18,7 +18,9 @@
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
 #include <dune/geometry/referenceelements.hh>
+#if ! DUNE_VERSION_NEWER(DUNE_GEOMETRY, 2, 5)
 #include <dune/geometry/genericgeometry/matrixhelper.hh>
+#endif
 #include <dune/grid/common/mcmgmapper.hh>
 
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
@@ -422,12 +424,16 @@ class HexGeometry<2, cdim, GridImp>
       LocalCoordinate x = refElement.position(0,0);
       LocalCoordinate dx;
       do {
-        using namespace Dune::GenericGeometry;
         // DF^n dx^n = F^n, x^{n+1} -= dx^n
         JacobianTransposed JT = jacobianTransposed(x);
         GlobalCoordinate z = global(x);
         z -= y;
+#if DUNE_VERSION_NEWER(DUNE_GEOMETRY, 2, 5)
+        Dune::Impl::FieldMatrixHelper<double>::template xTRightInvA<2, 2>(JT, z, dx );
+#else
+        using namespace Dune::GenericGeometry;
         MatrixHelper<DuneCoordTraits<double> >::template xTRightInvA<2, 2>(JT, z, dx );
+#endif
         x -= dx;
       } while (dx.two_norm2() > epsilon*epsilon);
       return x;
@@ -478,8 +484,12 @@ class HexGeometry<2, cdim, GridImp>
     ctype integrationElement(const LocalCoordinate& local) const
     {
       Dune::FieldMatrix<ctype, coorddimension, mydimension> Jt = jacobianTransposed(local);
+#if DUNE_VERSION_NEWER(DUNE_GEOMETRY, 2, 5)
+      return Dune::Impl::FieldMatrixHelper<double>::template sqrtDetAAT<2, 2>(Jt);
+#else
       using namespace Dune::GenericGeometry;
       return MatrixHelper<DuneCoordTraits<double> >::template sqrtDetAAT<2, 2>(Jt);
+#endif
     }
   private:
     //! \brief The coordinates of the corners

--- a/opm/elasticity/elasticity_preconditioners.hpp
+++ b/opm/elasticity/elasticity_preconditioners.hpp
@@ -191,7 +191,7 @@ struct AMG2Level {
     crit.setDefaultValuesIsotropic(3, zcells);
     CoarsePolicy coarsePolicy(args, crit);
     TransferPolicy policy(crit);
-    Dune::shared_ptr<Schwarz::type> fsp(Schwarz::setup2(op, gv, A, copy));
+    std::shared_ptr<Schwarz::type> fsp(Schwarz::setup2(op, gv, A, copy));
     copy = true;
     return std::shared_ptr<type>(new type(*op, fsp, policy, coarsePolicy, pre, post));
   }

--- a/opm/elasticity/elasticity_upscale_impl.hpp
+++ b/opm/elasticity/elasticity_upscale_impl.hpp
@@ -42,7 +42,7 @@ IMPL_FUNC(std::vector<BoundaryGrid::Vertex>,
   for (LeafVertexIterator it = start; it != itend; ++it) {
     if (isOnPlane(dir,it->geometry().corner(0),coord)) {
       BoundaryGrid::Vertex v;
-      v.i = mapper.map(*it);
+      v.i = mapper.index(*it);
       BoundaryGrid::extract(v.c,it->geometry().corner(0),log2(dir));
       result.push_back(v);
     }
@@ -378,7 +378,7 @@ IMPL_FUNC(void, fixPoint(Direction dir,
   // iterate over vertices
   for (VertexLeafIterator it = gv.leafGridView().template begin<dim>(); it != itend; ++it) {
     if (isOnPoint(it->geometry().corner(0),coord)) {
-      int indexi = mapper.map(*it);
+      int indexi = mapper.index(*it);
       A.updateFixedNode(indexi,std::make_pair(dir,value));
     }
   }
@@ -409,7 +409,7 @@ IMPL_FUNC(void, fixLine(Direction dir,
   // iterate over vertices
   for (VertexLeafIterator it = gv.leafGridView().template begin<dim>(); it != itend; ++it) {
     if (isOnLine(dir,it->geometry().corner(0),x,y)) {
-      int indexi = mapper.map(*it);
+      int indexi = mapper.index(*it);
       A.updateFixedNode(indexi,std::make_pair(XYZ,value));
     }
   }

--- a/opm/elasticity/elasticity_upscale_impl.hpp
+++ b/opm/elasticity/elasticity_upscale_impl.hpp
@@ -1041,7 +1041,7 @@ IMPL_FUNC(void, setupSolvers(const LinSolParams& params))
                                                                                params.tol,
                                                                                params.restart,
                                                                                params.maxit,
-                                                                               verbose?2:(params.report?1:0), true)));
+                                                                               verbose?2:(params.report?1:0))));
         }
       }
     } else {

--- a/opm/porsol/common/GridInterfaceEuler.hpp
+++ b/opm/porsol/common/GridInterfaceEuler.hpp
@@ -103,7 +103,7 @@ namespace Opm
         class Face {
         public:
             typedef typename GI::DuneIntersectionIterator                   DuneIntersectionIter;
-            typedef typename GI::GridType::template Codim<0>::EntityPointer CellPtr;
+            typedef typename GI::GridType::Traits::template Codim<0>::EntityPointer CellPtr;
             typedef typename GI::GridType::ctype                            Scalar;
             typedef          Dune::FieldVector<Scalar, GI::GridType::dimension>   Vector;
             typedef          Dune::FieldVector<Scalar, GI::GridType::dimension-1> LocalVector;

--- a/opm/porsol/mimetic/IncompFlowSolverHybrid.hpp
+++ b/opm/porsol/mimetic/IncompFlowSolverHybrid.hpp
@@ -1616,8 +1616,7 @@ namespace Opm {
         // ----------------------------------------------------------------
         {        
             
-            typedef Dune::Amg::KAMG<Operator,Vector,Smoother,Dune::Amg::SequentialInformation,
-                              Dune::CGSolver<Vector> >   Precond;
+            typedef Dune::Amg::KAMG<Operator,Vector,Smoother,Dune::Amg::SequentialInformation> Precond;
             // Adapted from upscaling.cc by Arne Rekdal, 2009
             Scalar residTol = residual_tolerance;
             if (!same_matrix) {
@@ -1642,7 +1641,10 @@ namespace Opm {
 #endif
                 criterion.setProlongationDampingFactor(prolong_factor);
                 criterion.setBeta(1e-10);
-                precond_.reset(new Precond(*opS_, criterion, smootherArgs, 2, smooth_steps, smooth_steps));
+                criterion.setNoPreSmoothSteps(smooth_steps);
+                criterion.setNoPostSmoothSteps(smooth_steps);
+                criterion.setGamma(2);
+                precond_.reset(new Precond(*opS_, criterion, smootherArgs));
             }
             // Construct solver for system of linear equations.
             Dune::CGSolver<Vector> linsolve(*opS_, dynamic_cast<Precond&>(*precond_), residTol, (maxit>0)?maxit:S_.N(), verbosity_level);


### PR DESCRIPTION
OPM (in particular simulators) now depends on dune 2.4 for proper behavior. This makes this requirement hard.