### PR TITLE
fixed: look for last dot, not first

### DIFF
--- a/examples/upscale_relperm.cpp
+++ b/examples/upscale_relperm.cpp
@@ -206,7 +206,7 @@ static int parseCommandLine(std::map<std::string,std::string>& options,
 //! \return Eclipse-style filename for requested component/fluid system combination.
 static std::string getEclipseOutputFile(const std::string& opfname, char comp, char sat)
 {
-    string fnbase = opfname.substr(0,opfname.find_first_of('.'));
+    string fnbase = opfname.substr(0,opfname.find_last_of('.'));
     return fnbase + "-" +comp + ".S" + sat + "OF";
 }
 


### PR DESCRIPTION
resulted in unexpected file names if path held a dot.

In particular this was seen on jenkins, where the dune 2.4 build has a dot in the configuration name. We ended up with files named 'dune-2-X.SWOF' et al on top of workspace.