### PR TITLE
dune.module: advertise opm-output as a dependency

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -10,4 +10,4 @@ Label: 2018.04-pre
 Maintainer: arne.morten.kvarving@sintef.no
 MaintainerName: Arne Morten Kvarving
 Url: http://opm-project.org
-Depends: dune-common (>= 2.4) dune-grid (>= 2.4) dune-istl (>= 2.4) opm-parser opm-common opm-grid
+Depends: dune-common (>= 2.4) dune-grid (>= 2.4) dune-istl (>= 2.4) opm-parser opm-common opm-output opm-grid


### PR DESCRIPTION
this is now required because opm-core is gone and thus opm-output is no longer implicitly available.