### PR TITLE
Fix issue 259

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -80,6 +80,7 @@ list (APPEND TEST_DATA_FILES
   tests/input_data/reference_solutions/upscale_elasticity_mortar_EightCells.txt
   tests/input_data/reference_solutions/upscale_elasticity_mpc_EightCells.txt
   tests/input_data/reference_solutions/upscale_elasticity_mortar_EightCells.txt
+  tests/input_data/reference_solutions/cpchop_PeriodicTilted.txt
 )
 
 # originally generated with the command:

--- a/compareUpscaling.cmake
+++ b/compareUpscaling.cmake
@@ -30,11 +30,11 @@ set(BASE_RESULT_PATH ${PROJECT_BINARY_DIR}/tests/results)
 set(INPUT_DATA_PATH ${PROJECT_BINARY_DIR}/tests/input_data)
 
 ###########################################################################
-# TEST: upscale_perm 
+# TEST: upscale_perm
 ###########################################################################
 
 # Define macro that performs the two steps mentioned above for upscale_perm
-# Input: 
+# Input:
 #   - gridname: basename (no extension) of grid model
 #   - bcs: Boundary condition type (f, l or p, or combinations of these)
 #   - rows: Number of rows in result file that is to be compared
@@ -50,18 +50,18 @@ macro (add_test_upscale_perm gridname bcs rows)
                DRIVER_ARGS ${INPUT_DATA_PATH} ${RESULT_PATH}
                            ${PROJECT_BINARY_DIR}/bin
                            upscale_perm_BC${bcs}_${gridname}
-                           ${abstol} ${reltol} 
+                           ${abstol} ${reltol}
                TEST_ARGS -bc ${bcs}
                          -output ${RESULT_PATH}/upscale_perm_BC${bcs}_${gridname}.txt
                          ${INPUT_DATA_PATH}/grids/${gridname}.grdecl)
 endmacro (add_test_upscale_perm)
 
 ###########################################################################
-# TEST: upscale_relperm 
+# TEST: upscale_relperm
 ###########################################################################
 
 # Define macro that performs the two steps mentioned above for upscale_relperm
-# Input: 
+# Input:
 #   - gridname: basename (no extension) of grid model
 #   - rows: Number of rows in result file that is to be compared
 # This macro assumes that ${gridname}.grdecl is found in directory ${INPUT_DATA_PATH}grids/
@@ -91,7 +91,7 @@ endmacro ()
 ###########################################################################
 
 # Define macro that performs the two steps mentioned above for upscale_elasticity
-# Input: 
+# Input:
 #   - gridname: basename (no extension) of grid model
 #   - method: method to apply
 # This macro assumes that ${gridname}.grdecl is found in directory ${INPUT_DATA_PATH}grids/
@@ -106,12 +106,35 @@ macro (add_test_upscale_elasticity gridname method)
                DRIVER_ARGS ${INPUT_DATA_PATH} ${RESULT_PATH}
                            ${PROJECT_BINARY_DIR}/bin
                            upscale_elasticity_${method}_${gridname}
-                           ${abstol} ${reltol} 
+                           ${abstol} ${reltol}
                TEST_ARGS output=${RESULT_PATH}/upscale_elasticity_${method}_${gridname}.txt
                          gridfilename=${INPUT_DATA_PATH}/grids/${gridname}.grdecl
                          output_wave_speeds=true
                          method=${method})
-endmacro (add_test_upscale_elasticity gridname method rows)
+endmacro ()
+
+# TEST: cpchop
+###########################################################################
+
+# Define macro that performs the two steps mentioned above for cpchop
+# Input:
+#   - gridname: basename (no extension) of grid model
+# This macro assumes that ${gridname}.grdecl is found in directory ${INPUT_DATA_PATH}grids/
+# and that cpcho_${gridname}.txt is found in ${INPUT_DATA_PATH}reference_solutions
+macro (add_test_cpchop gridname)
+  # Add test that runs cpchop and outputs the results to file
+  # Ensure unique output folder per test (because this folder is deleted in the test driver script)
+  set(TEST_NAME cpchop_${gridname})
+  set(RESULT_PATH ${BASE_RESULT_PATH}/${TEST_NAME})
+  opm_add_test(${TEST_NAME} NO_COMPILE
+               EXE_NAME cpchop
+               DRIVER_ARGS ${INPUT_DATA_PATH} ${RESULT_PATH}
+                           ${PROJECT_BINARY_DIR}/bin
+                           cpchop_${gridname}
+                           ${abstol} ${reltol}
+               TEST_ARGS resultfile=${RESULT_PATH}/cpchop_${gridname}.txt use_random=false
+                         gridfilename=${INPUT_DATA_PATH}/grids/${gridname}.grdecl)
+endmacro ()
 
 # Make sure that we build the helper executable before running tests
 # (the "tests" target is setup in OpmLibMain.cmake)
@@ -160,3 +183,5 @@ if((DUNE_ISTL_VERSION_MAJOR GREATER 2) OR
   add_test_upscale_elasticity(EightCells mpc)
   add_test_upscale_elasticity(EightCells mortar)
 endif()
+
+add_test_cpchop(PeriodicTilted)

--- a/examples/cpchop.cpp
+++ b/examples/cpchop.cpp
@@ -93,6 +93,7 @@ try
     std::string bc = param.getDefault<std::string>("bc", "fixed");
     bool resettoorigin = param.getDefault("resettoorigin", true);
     boost::mt19937::result_type userseed = param.getDefault("seed", 0);
+    bool use_random = param.getDefault("use_random", true);
 
     int outputprecision = param.getDefault("outputprecision", 8);
     std::string filebase = param.getDefault<std::string>("filebase", "");
@@ -310,9 +311,9 @@ try
 
     int finished_subsamples = 0; // keep explicit count of successful subsamples
     for (int sample = 1; sample <= subsamples; ++sample) {
-        int istart = ri();
-        int jstart = rj();
-        double zstart = rz();
+        int istart = use_random ? ri() : 0;
+        int jstart = use_random ? rj() : 0;
+        double zstart = use_random ? rz() : zmin;
         ch.chop(istart, istart + ilen, jstart, jstart + jlen, zstart, zstart + zlen, resettoorigin);
         std::string subsampledgrdecl = filebase;
 

--- a/examples/cpchop.cpp
+++ b/examples/cpchop.cpp
@@ -282,7 +282,7 @@ try
     // Note that end is included in interval for uniform_int.
     boost::uniform_int<> disti(imin, imax - ilen);
     boost::uniform_int<> distj(jmin, jmax - jlen);
-    boost::uniform_real<> distz(zmin, std::max(zmax - zlen, zmin));
+    boost::uniform_real<> distz(zmin, std::max(zmax - zlen, zmin+1e-6));
     boost::variate_generator<boost::mt19937&, boost::uniform_int<> > ri(gen, disti);
     boost::variate_generator<boost::mt19937&, boost::uniform_int<> > rj(gen, distj);
     boost::variate_generator<boost::mt19937&, boost::uniform_real<> > rz(gen, distz);

--- a/opm/upscaling/CornerpointChopper.hpp
+++ b/opm/upscaling/CornerpointChopper.hpp
@@ -40,14 +40,10 @@ namespace Opm
     class CornerPointChopper
     {
     public:
-        CornerPointChopper(const std::string& file)
+        CornerPointChopper(const std::string& file) :
+          deck_(Parser{}.parseFile(file, ParseContext{})),
+          metricUnits_(Opm::UnitSystem::newMETRIC())
         {
-            Opm::ParseContext parseContext;
-            Opm::Parser parser;
-            deck_ = parser.parseFile(file , parseContext);
-
-            metricUnits_ = Opm::UnitSystem::newMETRIC();
-
             const auto& specgridRecord = deck_.getKeyword("SPECGRID").getRecord(0);
             dims_[0] = specgridRecord.getItem("NX").get< int >(0);
             dims_[1] = specgridRecord.getItem("NY").get< int >(0);

--- a/tests/input_data/reference_solutions/cpchop_PeriodicTilted.txt
+++ b/tests/input_data/reference_solutions/cpchop_PeriodicTilted.txt
@@ -1,0 +1,16 @@
+################################################################################################
+# Results from property analysis on subsamples
+#
+# Finished: Wed Aug  1 11:33:00 2018
+# Hostname: akvalung
+#
+# Options used:
+#     gridfilename: /home/akva/kode/opm/opm-upscaling/build/tests/input_data/grids/PeriodicTilted.grdecl
+#   i; min,len,max: 0 20 20
+#   j; min,len,max: 0 20 20
+#   z; min,len,max: 0 40 40
+#       subsamples: 1
+#      (auto) seed: 1533115973
+################################################################################################
+# id          porosity                 permx                   permy                   permz
+1	      0.33999965	       409.26845	       549.99606	       238.51632	


### PR DESCRIPTION
Two problems:

- non-empty interval for the random number generator for z starting coordinates
- problematic cc for the Deck class. workaround by moving to initializer list so move semantics are used.