### PR TITLE
Fix dangling reference as cell returns a copy of geometry now.

### DIFF
--- a/opm/upscaling/RelPermUtils.cpp
+++ b/opm/upscaling/RelPermUtils.cpp
@@ -701,7 +701,8 @@ void RelPermUpscaleHelper::calculateCellPressureGradients()
             grid.getIJK(ix, ijk);
             mt.activateCell(ijk);
 
-            const auto& cc = c->geometry().center();
+            const auto & geom = c->geometry(); //geometry() returns a copy that now lives on.
+            const auto & cc = geom.center();
             celldepth[ix]  = cc[ cc.size() - 1 ];
         }
     }


### PR DESCRIPTION
When geometry returned a reference we could simply store a
reference to its stored center. With geometry returned as a copy this
has become a dangling reference. We fix this by storing a constant reference
to the geometry and then reference its center.

This change is needed for the PR OPM/opm-grid#334