### PR TITLE
fixed: set HAVE_OPENMP in the header file

### DIFF
--- a/opm-upscaling-prereqs.cmake
+++ b/opm-upscaling-prereqs.cmake
@@ -1,6 +1,7 @@
 # defines that must be present in config.h for our headers
 set (opm-upscaling_CONFIG_VAR
   HAVE_SUPERLU
+  HAVE_OPENMP
   )
 
 # dependencies


### PR DESCRIPTION
the elasticity code relies on this for the runtime openmp interaction.