### PR TITLE
Pass a pointer to the EclipseGrid to CpGrid::processEclipseGrid.

### DIFF
--- a/examples/upscale_elasticity.cpp
+++ b/examples/upscale_elasticity.cpp
@@ -301,7 +301,7 @@ int run(Params& p)
         Opm::Parser parser;
         auto deck = parser.parseFile(p.file);
         Opm::EclipseGrid inputGrid(deck);
-        grid.processEclipseFormat(inputGrid, false);
+        grid.processEclipseFormat(&inputGrid, false);
     }
     ElasticityUpscale<GridType, AMG> upscale(grid, p.ctol, p.Emin, p.file,
                                              p.rocklist, p.verbose);

--- a/opm/porsol/common/setupGridAndProps.hpp
+++ b/opm/porsol/common/setupGridAndProps.hpp
@@ -91,7 +91,7 @@ namespace Opm
             bool turn_normals = param.getDefault<bool>("turn_normals", false);
             {
                 Opm::EclipseGrid inputGrid(deck);
-                grid.processEclipseFormat(inputGrid, periodic_extension, turn_normals, clip_z);
+                grid.processEclipseFormat(&inputGrid, periodic_extension, turn_normals, clip_z);
             }
             // Save EGRID file in case we are writing ECL output.
             if (param.getDefault("output_ecl", false)) {
@@ -161,7 +161,7 @@ namespace Opm
     {
         Opm::EclipseGrid eg(deck);
         const std::string* rl_ptr = (rock_list == "no_list") ? 0 : &rock_list;
-        grid.processEclipseFormat(eg, periodic_extension, turn_normals, clip_z);
+        grid.processEclipseFormat(&eg, periodic_extension, turn_normals, clip_z);
         res_prop.init(deck, grid.globalCell(), perm_threshold, rl_ptr, use_jfunction_scaling, sigma, theta);
         if (unique_bids) {
             grid.setUniqueBoundaryIds(true);

--- a/opm/upscaling/initCPGrid.cpp
+++ b/opm/upscaling/initCPGrid.cpp
@@ -61,7 +61,7 @@ void Opm::initCPGrid(Dune::CpGrid& grid, const Opm::ParameterGroup& param) {
         Opm::Parser parser;
         auto deck = parser.parseFile(filename);
         Opm::EclipseGrid inputGrid(deck);
-        grid.processEclipseFormat(inputGrid, periodic_extension , turn_normals );
+        grid.processEclipseFormat(&inputGrid, periodic_extension , turn_normals );
     } else if (fileformat == "cartesian") {
         std::array<int, 3> dims = {{ param.getDefault<int>("nx", 1),
                                      param.getDefault<int>("ny", 1),


### PR DESCRIPTION
... instead of a reference This is needed as we only want to read the
full deck and construct the EclipseGrid only on the master process
with rank 0. Hence all other ranks will pass a nullptr to this
function. This will be possible with this move from a reference to a
pointer.

downstream of PR OPM/opm-grid#433