### PR TITLE
Use specific headers S.hpp and P.hpp

### DIFF
--- a/opm/upscaling/RelPermUtils.cpp
+++ b/opm/upscaling/RelPermUtils.cpp
@@ -21,7 +21,8 @@
 
 #include <opm/upscaling/RelPermUtils.hpp>
 
-#include <opm/parser/eclipse/Parser/ParserKeywords.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/P.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/S.hpp>
 
 #include <opm/parser/eclipse/Units/Units.hpp>
 


### PR DESCRIPTION
Preparation for removing the large keyword header.