### PR TITLE
Initialize gravity_ member.

### DIFF
--- a/opm/upscaling/UpscalerBase_impl.hpp
+++ b/opm/upscaling/UpscalerBase_impl.hpp
@@ -53,7 +53,8 @@ namespace Opm
 	  linsolver_prolongate_factor_(1.0),
 	  linsolver_verbosity_(0),
           linsolver_type_(3),
-          linsolver_smooth_steps_(1)
+          linsolver_smooth_steps_(1),
+          gravity_(0.0)
     {
     }
 
@@ -92,6 +93,7 @@ namespace Opm
         linsolver_maxit_ = param.getDefault("linsolver_max_iterations", linsolver_maxit_);
         linsolver_prolongate_factor_ = param.getDefault("linsolver_prolongate_factor", linsolver_prolongate_factor_);
         linsolver_smooth_steps_ = param.getDefault("linsolver_smooth_steps", linsolver_smooth_steps_);
+        gravity_ = param.getDefault("gravity", gravity_);
 
         // Ensure sufficient grid support for requested boundary
         // condition type.


### PR DESCRIPTION
This turned out to be unrelated to #308, but was discovered during testing for that fix.

The bug is pretty serious, and could have bitten anytime. On the plus side, uninitialized non-zero data are likely to be much larger than any sensible gravity acceleration, so it was more likely to cause failures (as for me) than wrong results.