### PR TITLE
changed: remove multiarch-support predepends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,7 @@ Description: OPM upscaling library -- applications
 
 Package: libopm-upscaling1
 Section: libs
-Pre-Depends: ${misc:Pre-Depends}, multiarch-support
+Pre-Depends: ${misc:Pre-Depends}
 Architecture: any
 Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends}


### PR DESCRIPTION
no longer required in ubuntu bionic, and breaks ubuntu focal,
and in any case it is support by both platforms.

Missing milestone in this repo, but this should also be backported.