### PR TITLE
build packages with OpenMP enabled

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -21,7 +21,7 @@ override_dh_auto_build:
 
 # consider using -DUSE_VERSIONED_DIR=ON if backporting
 override_dh_auto_configure:
-	dh_auto_configure --buildsystem=cmake -- -DCMAKE_BUILD_TYPE=Release -DUSE_MPI=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_DOCDIR=share/doc/libopm-upscaling1 -DWHOLE_PROG_OPTIM=OFF -DUSE_RUNPATH=OFF -DINSTALL_BENCHMARKS=1 -DWITH_NATIVE=OFF -DUSE_OPENMP=0
+	dh_auto_configure --buildsystem=cmake -- -DCMAKE_BUILD_TYPE=Release -DUSE_MPI=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_DOCDIR=share/doc/libopm-upscaling1 -DWHOLE_PROG_OPTIM=OFF -DUSE_RUNPATH=OFF -DINSTALL_BENCHMARKS=1 -DWITH_NATIVE=OFF
 
 override_dh_auto_install:
 	dh_auto_install -- install-html


### PR DESCRIPTION
accidentially discovered that we build without openmp, because -DUSE_OPENMP=0 is broken now (if opm-common was built with openmp).

Backport.