### PR TITLE
Bring in Missing <time.h> Header

### DIFF
--- a/opm/upscaling/writeECLData.hpp
+++ b/opm/upscaling/writeECLData.hpp
@@ -23,6 +23,8 @@
 
 #include <string>
 
+#include <time.h>
+
 #include <opm/output/data/Solution.hpp>
 
 namespace Opm


### PR DESCRIPTION
Needed to bring a declaration of 'time_t' into scope.

Submitted by: Edscott Wilson Garcia

Fixes #322 