### PR TITLE
Stop pretending that we support CMake 2.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 # Mandatory call to project
 project(opm-upscaling C CXX)
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.10)
 
 option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)
 option(INSTALL_BENCHMARKS "Install benchmark applications?" OFF)


### PR DESCRIPTION
We actually already require at least CMake 2.8.12 due to the embedded pybind11 (some tests of it are even at 3.0). Anyway as  Ubuntu LTS has 3.10.2 I doubt that anything less is tested by us.