### PR TITLE
add libpython3-dev to debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Maintainer: Arne Morten Kvarving <arne.morten.kvarving@sintef.no>
 Build-Depends: build-essential, debhelper (>= 9),
                libboost-system-dev, libboost-date-time-dev, libboost-test-dev,
                libsuperlu3-dev (>= 3.0) | libsuperlu-dev (>= 4.3),
-               gfortran, libsuitesparse-dev,
+               gfortran, libsuitesparse-dev, libpython3-dev,
                libdune-common-dev, libdune-istl-dev, cmake, libtinyxml-dev, bc,
                git, zlib1g-dev, libtool, libopm-material-dev,
                libopm-grid-dev, libdune-grid-dev, libscotchmetis-dev, libscotchparmetis-dev,


### PR DESCRIPTION
needed since we now build embedded python support
in opm-common