### PR TITLE
Support Dune 2.8 version of MultipleCodimMultipleGeomTypeMapper

### DIFF
--- a/opm/elasticity/boundarygrid.hh
+++ b/opm/elasticity/boundarygrid.hh
@@ -19,6 +19,7 @@
 #include <dune/common/fmatrix.hh>
 #include <dune/geometry/referenceelements.hh>
 #include <dune/grid/common/mcmgmapper.hh>
+#include <dune/grid/common/defaultgridview.hh>
 
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
@@ -326,11 +327,12 @@ class HexGeometry<2, cdim, GridImp>
     //! \param[in] dir The direction of the normal vector on the face
     HexGeometry(const BoundaryGrid::Quad& q, const GridImp& gv, int dir)
     {
-      Dune::LeafMultipleCodimMultipleGeomTypeMapper<GridImp> mapper(gv, Dune::mcmgVertexLayout());
-      typename GridImp::LeafGridView::template Codim<3>::Iterator start=gv.leafGridView().template begin<3>();
-      const typename GridImp::LeafGridView::template Codim<3>::Iterator itend = gv.leafGridView().template end<3>();
+      using LeafGridView = Dune::GridView<Dune::DefaultLeafGridViewTraits<GridImp>>;
+      Dune::MultipleCodimMultipleGeomTypeMapper<LeafGridView> mapper(gv.leafGridView(), Dune::mcmgVertexLayout());
+      typename LeafGridView::template Codim<3>::Iterator start=gv.leafGridView().template begin<3>();
+      const typename LeafGridView::template Codim<3>::Iterator itend = gv.leafGridView().template end<3>();
       for (int i=0;i<4;++i) {
-        typename GridImp::LeafGridView::template Codim<3>::Iterator it=start;
+        typename LeafGridView::template Codim<3>::Iterator it=start;
         for (; it != itend; ++it) {
           if (mapper.index(*it) == q.v[i].i)
             break;

--- a/opm/elasticity/elasticity_upscale_impl.hpp
+++ b/opm/elasticity/elasticity_upscale_impl.hpp
@@ -33,8 +33,9 @@ IMPL_FUNC(std::vector<BoundaryGrid::Vertex>,
   std::vector<BoundaryGrid::Vertex> result;
   const LeafVertexIterator itend = gv.leafGridView().template end<dim>();
 
-  // make a mapper for codim dim entities in the leaf grid 
-  Dune::LeafMultipleCodimMultipleGeomTypeMapper<GridType> mapper(gv, Dune::mcmgVertexLayout());
+  // make a mapper for codim dim entities in the leaf grid
+  using LeafGridView = Dune::GridView<Dune::DefaultLeafGridViewTraits<GridType>>;
+  Dune::MultipleCodimMultipleGeomTypeMapper<LeafGridView>  mapper(gv.leafGridView(), Dune::mcmgVertexLayout());
   // iterate over vertices and find slaves
   LeafVertexIterator start = gv.leafGridView().template begin<dim>();
   for (LeafVertexIterator it = start; it != itend; ++it) {
@@ -369,7 +370,8 @@ IMPL_FUNC(void, fixPoint(Direction dir,
   const VertexLeafIterator itend = gv.leafGridView().template end<dim>();
 
   // make a mapper for codim 0 entities in the leaf grid 
-  Dune::LeafMultipleCodimMultipleGeomTypeMapper<GridType> mapper(gv, Dune::mcmgVertexLayout());
+  using LeafGridView = Dune::GridView<Dune::DefaultLeafGridViewTraits<GridType>>;
+  Dune::MultipleCodimMultipleGeomTypeMapper<LeafGridView> mapper(gv.leafGridView(), Dune::mcmgVertexLayout());
 
   // iterate over vertices
   for (VertexLeafIterator it = gv.leafGridView().template begin<dim>(); it != itend; ++it) {
@@ -398,8 +400,9 @@ IMPL_FUNC(void, fixLine(Direction dir,
   typedef typename GridType::LeafGridView::template Codim<dim>::Iterator VertexLeafIterator;
   const VertexLeafIterator itend = gv.leafGridView().template end<dim>();
 
-  // make a mapper for codim 0 entities in the leaf grid 
-  Dune::LeafMultipleCodimMultipleGeomTypeMapper<GridType> mapper(gv, Dune::mcmgVertexLayout());
+  // make a mapper for codim 0 entities in the leaf grid
+  using LeafGridView = Dune::GridView<Dune::DefaultLeafGridViewTraits<GridType>>;
+  Dune::MultipleCodimMultipleGeomTypeMapper<LeafGridView> mapper(gv, Dune::mcmgVertexLayout());
 
   // iterate over vertices
   for (VertexLeafIterator it = gv.leafGridView().template begin<dim>(); it != itend; ++it) {


### PR DESCRIPTION
Drop removed second template parameter from MultipleCodimMultipleGeomTypeMapper (there is a default since 2.6
and now the second parameter is gone). 
Also fixes some other deprecation warnings about the deprecated LeafMultipleCodimMultipleGeomTypeMapper