### PR TITLE
update redhat packaging

### DIFF
--- a/redhat/opm-upscaling.spec
+++ b/redhat/opm-upscaling.spec
@@ -3,6 +3,11 @@
 #
 
 %define tag final
+%define rtype release
+%define toolset devtoolset-9
+%define build_openmpi 1
+%define build_openmpi3 1
+%define build_mpich 1
 
 Name:           opm-upscaling
 Version:        2018.10
@@ -12,41 +17,69 @@ License:        GPL-3.0
 Group:          Development/Libraries/C and C++
 Url:            http://www.opm-project.org/
 Source0:        https://github.com/OPM/%{name}/archive/release/%{version}/%{tag}.tar.gz#/%{name}-%{version}.tar.gz
-BuildRequires:  blas-devel lapack-devel dune-common-devel opm-grid-devel
-BuildRequires:  git suitesparse-devel doxygen bc dune-geometry-devel
-BuildRequires:  tinyxml-devel dune-istl-devel opm-common-devel
-BuildRequires:  opm-material-devel dune-grid-devel
-BuildRequires:  zlib-devel
-BuildRequires:  openmpi-devel trilinos-openmpi-devel ptscotch-openmpi-devel scotch-devel opm-common-openmpi-devel opm-grid-openmpi-devel opm-material-openmpi-devel
-BuildRequires:  mpich-devel trilinos-mpich-devel ptscotch-mpich-devel opm-common-mpich-devel opm-grid-mpich-devel opm-material-mpich-devel
-BuildRequires: cmake3
-%{?!el8:BuildRequires: devtoolset-8-toolchain}
-BuildRequires: boost-devel
+BuildRequires:  blas-devel lapack-devel
+BuildRequires:  git suitesparse-devel doxygen bc tinxyml-devel
+BuildRequires:  cmake zlib-devel graphviz
+BuildRequires: %{toolset}-toolchain
+BuildRequires: boost-devel python3-devel tbb-devel
+BuildRequires: dune-common-devel
+BuildRequires: dune-geometry-devel
+BuildRequires: dune-istl-devel
+BuildRequires: dune-uggrid-devel
+BuildRequires: dune-grid-devel
+BuildRequires: opm-common-devel
+BuildRequires: opm-grid-devel
+BuildRequires: opm-material-devel
+
+%if %{build_openmpi}
+BuildRequires: openmpi-devel
+BuildRequires: opm-common-openmpi-devel
+BuildRequires: opm-grid-openmpi-devel
+BuildRequires: opm-material-openmpi-devel
+BuildRequires: zoltan-openmpi-devel
+BuildRequires: dune-common-openmpi-devel
+BuildRequires: dune-grid-openmpi-devel
+BuildRequires: dune-geometry-openmpi-devel
+BuildRequires: dune-istl-openmpi-devel
+BuildRequires: dune-uggrid-openmpi-devel
+%endif
+
+%if %{build_openmpi3}
+BuildRequires: openmpi3-devel
+BuildRequires: opm-common-openmpi3-devel
+BuildRequires: opm-grid-openmpi3-devel
+BuildRequires: opm-material-openmpi3-devel
+BuildRequires: zoltan-openmpi3-devel
+BuildRequires: dune-common-openmpi3-devel
+BuildRequires: dune-grid-openmpi3-devel
+BuildRequires: dune-geometry-openmpi3-devel
+BuildRequires: dune-istl-openmpi3-devel
+BuildRequires: dune-uggrid-openmpi3-devel
+%endif
+
+%if %{build_mpich}
+BuildRequires: mpich-devel
+BuildRequires: opm-common-mpich-devel
+BuildRequires: opm-grid-mpich-devel
+BuildRequires: opm-material-mpich-devel
+BuildRequires: zoltan-mpich-devel
+BuildRequires: dune-common-mpich-devel
+BuildRequires: dune-grid-mpich-devel
+BuildRequires: dune-geometry-mpich-devel
+BuildRequires: dune-istl-mpich-devel
+BuildRequires: dune-uggrid-mpich-devel
+%endif
+
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-Requires:       libopm-upscaling1 = %{version}
 
 %description
 This module provides semi-implicit pressure and transport solvers using the IMPES method.
 
-%package -n libopm-upscaling1
+%package -n libopm-upscaling%{opm_package_version}
 Summary:        Open Porous Media - upscaling library
 Group:          System/Libraries
 
-%description -n libopm-upscaling1
-This module implements single-phase and steady-state upscaling methods.
-
-%package -n libopm-upscaling1-openmpi
-Summary:        Open Porous Media - upscaling library
-Group:          System/Libraries
-
-%description -n libopm-upscaling1-openmpi
-This module implements single-phase and steady-state upscaling methods.
-
-%package -n libopm-upscaling1-mpich
-Summary:        Open Porous Media - upscaling library
-Group:          System/Libraries
-
-%description -n libopm-upscaling1-mpich
+%description -n libopm-upscaling%{opm_package_version}
 This module implements single-phase and steady-state upscaling methods.
 
 %package devel
@@ -56,33 +89,9 @@ Requires:       %{name} = %{version}
 Requires:       blas-devel
 Requires:       lapack-devel
 Requires:       suitesparse-devel
-Requires:       libopm-upscaling1 = %{version}
+Requires:       libopm-upscaling%{opm_package_version} = %{version}
 
 %description devel
-This package contains the development and header files for opm-upscaling
-
-%package openmpi-devel
-Summary:        Development and header files for opm-upscaling
-Group:          Development/Libraries/C and C++
-Requires:       %{name} = %{version}
-Requires:       blas-devel
-Requires:       lapack-devel
-Requires:       suitesparse-devel
-Requires:       libopm-upscaling1-openmpi = %{version}
-
-%description openmpi-devel
-This package contains the development and header files for opm-upscaling
-
-%package mpich-devel
-Summary:        Development and header files for opm-upscaling
-Group:          Development/Libraries/C and C++
-Requires:       %{name} = %{version}
-Requires:       blas-devel
-Requires:       lapack-devel
-Requires:       suitesparse-devel
-Requires:       libopm-upscaling1-mpich = %{version}
-
-%description mpich-devel
 This package contains the development and header files for opm-upscaling
 
 %package doc
@@ -93,96 +102,187 @@ BuildArch:	noarch
 %description doc
 This package contains the documentation files for opm-upscaling
 
-%package bin
+%package bin%{opm_package_version}
 Summary:        Applications in opm-upscaling
 Group:          Scientific
 Requires:       %{name} = %{version}
-Requires:       libopm-upscaling1 = %{version}
 
-%description bin
+%description bin%{opm_package_version}
 This package contains the applications for opm-upscaling
 
-%package openmpi-bin
+%if %{build_openmpi}
+%package -n libopm-upscaling-openmpi%{opm_package_version}
+Summary:        Open Porous Media - upscaling library
+Group:          System/Libraries
+
+%description -n libopm-upscaling-openmpi%{opm_package_version}
+This module implements single-phase and steady-state upscaling methods.
+
+%package openmpi-devel
+Summary:        Development and header files for opm-upscaling
+Group:          Development/Libraries/C and C++
+Requires:       %{name} = %{version}
+Requires:       blas-devel
+Requires:       lapack-devel
+Requires:       suitesparse-devel
+Requires:       libopm-upscaling-openmpi%{opm_package_version} = %{version}
+
+%description openmpi-devel
+This package contains the development and header files for opm-upscaling
+
+%package openmpi-bin%{opm_package_version}
 Summary:        Applications in opm-upscaling
 Group:          Scientific
 Requires:       %{name} = %{version}
-Requires:       libopm-upscaling1-openmpi = %{version}
-Requires:       libopm-grid1-openmpi = %{version}
-Requires:       libopm-common1-openmpi = %{version}
 
-%description openmpi-bin
+%description openmpi-bin%{opm_package_version}
 This package contains the applications for opm-upscaling
+%endif
 
-%package mpich-bin
+%if %{build_openmpi3}
+%package -n libopm-upscaling-openmpi3%{opm_package_version}
+Summary:        Open Porous Media - upscaling library
+Group:          System/Libraries
+
+%description -n libopm-upscaling-openmpi3%{opm_package_version}
+This module implements single-phase and steady-state upscaling methods.
+
+%package openmpi3-devel
+Summary:        Development and header files for opm-upscaling
+Group:          Development/Libraries/C and C++
+Requires:       %{name} = %{version}
+Requires:       blas-devel
+Requires:       lapack-devel
+Requires:       suitesparse-devel
+Requires:       libopm-upscaling-openmpi3%{opm_package_version} = %{version}
+
+%description openmpi3-devel
+This package contains the development and header files for opm-upscaling
+
+%package openmpi3-bin%{opm_package_version}
 Summary:        Applications in opm-upscaling
 Group:          Scientific
 Requires:       %{name} = %{version}
-Requires:       libopm-upscaling1-mpich = %{version}
-Requires:       libopm-grid1-mpich = %{version}
-Requires:       libopm-common1-mpich = %{version}
 
-%description mpich-bin
+%description openmpi3-bin%{opm_package_version}
 This package contains the applications for opm-upscaling
+%endif
+
+%if %{build_mpich}
+%package -n libopm-upscaling-mpich%{opm_package_version}
+Summary:        Open Porous Media - upscaling library
+Group:          System/Libraries
+
+%description -n libopm-upscaling-mpich%{opm_package_version}
+This module implements single-phase and steady-state upscaling methods.
+
+%package mpich-devel
+Summary:        Development and header files for opm-upscaling
+Group:          Development/Libraries/C and C++
+Requires:       %{name} = %{version}
+Requires:       blas-devel
+Requires:       lapack-devel
+Requires:       suitesparse-devel
+Requires:       libopm-upscaling-mpich%{opm_package_version} = %{version}
+
+%description mpich-devel
+This package contains the development and header files for opm-upscaling
+
+%package mpich-bin%{opm_package_version}
+Summary:        Applications in opm-upscaling
+Group:          Scientific
+Requires:       %{name} = %{version}
+
+%description mpich-bin%{opm_package_version}
+This package contains the applications for opm-upscaling
+%endif
 
 %global debug_package %{nil}
 
 %prep
-%setup -q -n %{name}-release-%{version}-%{tag}
+%setup -q -n %{name}-%{rtype}-%{version}-%{tag}
 
 # consider using -DUSE_VERSIONED_DIR=ON if backporting
 %build
 mkdir serial
-cd serial
-cmake3 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%{_prefix} -DCMAKE_INSTALL_DOCDIR=share/doc/%{name}-%{version} -DUSE_RUNPATH=OFF %{!?el8:-DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/g++ -DCMAKE_C_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/gcc -DCMAKE_Fortran_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/gfortran} -DINSTALL_BENCHMARKS=1 -DWITH_NATIVE=OFF ..
-make %{?_smp_mflags}
-make test
-cd ..
+pushd serial
+scl enable %{toolset} 'cmake3 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%{_prefix} -DCMAKE_INSTALL_DOCDIR=share/doc/%{name}-%{version} -DUSE_RUNPATH=OFF -DINSTALL_BENCHMARKS=1 -DWITH_NATIVE=OFF ..'
+scl enable %{toolset} 'make %{?_smp_mflags}'
+scl enable %{toolset} 'make test'
+popd
 
+%if %{build_openmpi}
 mkdir openmpi
-cd openmpi
-%{?el6:module load openmpi-x86_64}
-%{?!el6:module load mpi/openmpi-x86_64}
-cmake3 -DUSE_MPI=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%{_prefix}/lib64/openmpi -DCMAKE_INSTALL_LIBDIR=lib -DUSE_RUNPATH=OFF %{!?el8:-DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/g++ -DCMAKE_C_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/gcc -DCMAKE_Fortran_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/gfortran} -DINSTALL_BENCHMARKS=1 -DWITH_NATIVE=OFF -DZOLTAN_ROOT=/usr/lib64/openmpi -DCMAKE_CXX_FLAGS=-I/usr/include/openmpi-x86_64/trilinos -DZOLTAN_INCLUDE_DIRS=/usr/include/openmpi-x86_64/trilinos -DPTSCOTCH_ROOT=/usr/lib64/openmpi -DPTSCOTCH_INCLUDE_DIR=/usr/include/openmpi-x86_64 ..
-make %{?_smp_mflags}
-#make test
-cd ..
+pushd openmpi
+module load mpi/openmpi-x86_64
+scl enable %{toolset} 'cmake3 -DUSE_MPI=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%{_prefix}/lib64/openmpi -DCMAKE_INSTALL_LIBDIR=lib -DUSE_RUNPATH=OFF -DINSTALL_BENCHMARKS=1 -DWITH_NATIVE=OFF -DZOLTAN_ROOT=/usr/lib64/openmpi -DZOLTAN_INCLUDE_DIRS=/usr/include/openmpi-x86_64/zoltan ..'
+scl enable %{toolset} 'make %{?_smp_mflags}'
+scl enable %{toolset} 'make test'
+module unload mpi/openmpi-x86_64
+popd
+%endif
 
+%if %{build_openmpi3}
+mkdir openmpi3
+pushd openmpi3
+module load mpi/openmpi3-x86_64
+scl enable %{toolset} 'cmake3 -DUSE_MPI=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%{_prefix}/lib64/openmpi3 -DCMAKE_INSTALL_LIBDIR=lib -DUSE_RUNPATH=OFF -DINSTALL_BENCHMARKS=1 -DWITH_NATIVE=OFF -DZOLTAN_ROOT=/usr/lib64/openmpi3 -DZOLTAN_INCLUDE_DIRS=/usr/include/openmpi3-x86_64/zoltan ..'
+scl enable %{toolset} 'make %{?_smp_mflags}'
+scl enable %{toolset} 'make test'
+module unload mpi/openmpi3-x86_64
+popd
+%endif
+
+%if %{build_mpich}
 mkdir mpich
-cd mpich
-%{?el6:module rm openmpi-x86_64}
-%{?el6:module load mpich-x86_64}
-%{?!el6:module rm mpi/openmpi-x86_64}
-%{?!el6:module load mpi/mpich-x86_64}
-cmake3 -DUSE_MPI=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%{_prefix}/lib64/mpich -DCMAKE_INSTALL_LIBDIR=lib -DUSE_RUNPATH=OFF %{!?el8:-DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/g++ -DCMAKE_C_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/gcc -DCMAKE_Fortran_COMPILER=/opt/rh/devtoolset-8/root/usr/bin/gfortran} -DINSTALL_BENCHMARKS=1 -DWITH_NATIVE=OFF -DZOLTAN_ROOT=/usr/lib64/mpich -DCMAKE_CXX_FLAGS=-I/usr/include/mpich-x86_64/trilinos -DZOLTAN_INCLUDE_DIRS=/usr/include/mpich-x86_64/trilinos -DPTSCOTCH_ROOT=/usr/lib64/mpich -DPTSCOTCH_INCLUDE_DIR=/usr/include/mpich-x86_64 ..
-make %{?_smp_mflags}
-#make test
+pushd mpich
+module load mpi/mpich-x86_64
+scl enable %{toolset} 'cmake3 -DUSE_MPI=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%{_prefix}/lib64/mpich -DCMAKE_INSTALL_LIBDIR=lib -DUSE_RUNPATH=OFF -DINSTALL_BENCHMARKS=1 -DWITH_NATIVE=OFF -DZOLTAN_ROOT=/usr/lib64/mpich -DZOLTAN_INCLUDE_DIRS=/usr/include/mpich-x86_64/zoltan ..'
+scl enable %{toolset} 'make %{?_smp_mflags}'
+scl enable %{toolset} 'make test'
+module unload mpi/mpich-x86_64
+popd
+%endif
 
 %install
-cd serial
-make install DESTDIR=${RPM_BUILD_ROOT}
-make install-html DESTDIR=${RPM_BUILD_ROOT}
-cd ..
+scl enable %{toolset} 'make install DESTDIR=${RPM_BUILD_ROOT} -C serial'
+scl enable %{toolset} 'make install-html DESTDIR=${RPM_BUILD_ROOT} -C serial'
 
-cd openmpi
-make install DESTDIR=${RPM_BUILD_ROOT}
+%if %{build_openmpi}
+scl enable %{toolset} 'make install DESTDIR=${RPM_BUILD_ROOT} -C openmpi'
 mv ${RPM_BUILD_ROOT}/usr/lib64/openmpi/include/* ${RPM_BUILD_ROOT}/usr/include/openmpi-x86_64/
-cd ..
+%endif
 
-cd mpich
-make install DESTDIR=${RPM_BUILD_ROOT}
+%if %{build_openmpi3}
+scl enable %{toolset} 'make install DESTDIR=${RPM_BUILD_ROOT} -C openmpi3'
+mv ${RPM_BUILD_ROOT}/usr/lib64/openmpi3/include/* ${RPM_BUILD_ROOT}/usr/include/openmpi3-x86_64/
+%endif
+
+%if %{build_mpich}
+scl enable %{toolset} 'make install DESTDIR=${RPM_BUILD_ROOT} -C mpich'
 mv ${RPM_BUILD_ROOT}/usr/lib64/mpich/include/* ${RPM_BUILD_ROOT}/usr/include/mpich-x86_64/
-cd ..
+%endif
 
 %clean
 rm -rf %{buildroot}
 
-%post -n libopm-upscaling1 -p /sbin/ldconfig
-%post -n libopm-upscaling1-openmpi -p /sbin/ldconfig
-%post -n libopm-upscaling1-mpich -p /sbin/ldconfig
+%post -n libopm-upscaling%{opm_package_version} -p /sbin/ldconfig
+%postun -n libopm-upscaling%{opm_package_version} -p /sbin/ldconfig
 
-%postun -n libopm-upscaling1 -p /sbin/ldconfig
-%postun -n libopm-upscaling1-openmpi -p /sbin/ldconfig
-%postun -n libopm-upscaling1-mpich -p /sbin/ldconfig
+%if %{build_openmpi}
+%post -n libopm-upscaling-openmpi%{opm_package_version} -p /sbin/ldconfig
+%postun -n libopm-upscaling-openmpi%{opm_package_version} -p /sbin/ldconfig
+%endif
+
+%if %{build_openmpi3}
+%post -n libopm-upscaling-openmpi3%{opm_package_version} -p /sbin/ldconfig
+%postun -n libopm-upscaling-openmpi3%{opm_package_version} -p /sbin/ldconfig
+%endif
+
+%if %{build_mpich}
+%post -n libopm-upscaling-mpich%{opm_package_version} -p /sbin/ldconfig
+%postun -n libopm-upscaling-mpich%{opm_package_version} -p /sbin/ldconfig
+%endif
 
 %files
 %doc README COPYING
@@ -190,17 +290,9 @@ rm -rf %{buildroot}
 %files doc
 %{_docdir}/*
 
-%files -n libopm-upscaling1
+%files -n libopm-upscaling%{opm_package_version}
 %defattr(-,root,root,-)
 %{_libdir}/*.so.*
-
-%files -n libopm-upscaling1-openmpi
-%defattr(-,root,root,-)
-%{_libdir}/openmpi/lib/*.so.*
-
-%files -n libopm-upscaling1-mpich
-%defattr(-,root,root,-)
-%{_libdir}/mpich/lib/*.so.*
 
 %files devel
 %defattr(-,root,root,-)
@@ -211,6 +303,15 @@ rm -rf %{buildroot}
 %{_datadir}/cmake/*
 %{_datadir}/opm/cmake/Modules/*
 
+%files bin%{opm_package_version}
+%{_bindir}/*
+%{_datadir}/man/*
+
+%if %{build_openmpi}
+%files -n libopm-upscaling-openmpi%{opm_package_version}
+%defattr(-,root,root,-)
+%{_libdir}/openmpi/lib/*.so.*
+
 %files openmpi-devel
 %defattr(-,root,root,-)
 %{_libdir}/openmpi/lib/*.so
@@ -219,6 +320,35 @@ rm -rf %{buildroot}
 %{_includedir}/openmpi-x86_64/*
 %{_libdir}/openmpi/share/cmake/*
 %{_libdir}/openmpi/share/opm/cmake/Modules/*
+
+%files openmpi-bin%{opm_package_version}
+%{_libdir}/openmpi/bin/*
+%{_libdir}/openmpi/share/man/*
+%endif
+
+%if %{build_openmpi3}
+%files -n libopm-upscaling-openmpi3%{opm_package_version}
+%defattr(-,root,root,-)
+%{_libdir}/openmpi3/lib/*.so.*
+
+%files openmpi3-devel
+%defattr(-,root,root,-)
+%{_libdir}/openmpi3/lib/*.so
+%{_libdir}/openmpi3/lib/dunecontrol/*
+%{_libdir}/openmpi3/lib/pkgconfig/*
+%{_includedir}/openmpi3-x86_64/*
+%{_libdir}/openmpi3/share/cmake/*
+%{_libdir}/openmpi3/share/opm/cmake/Modules/*
+
+%files openmpi3-bin%{opm_package_version}
+%{_libdir}/openmpi3/bin/*
+%{_libdir}/openmpi3/share/man/*
+%endif
+
+%if %{build_mpich}
+%files -n libopm-upscaling-mpich%{opm_package_version}
+%defattr(-,root,root,-)
+%{_libdir}/mpich/lib/*.so.*
 
 %files mpich-devel
 %defattr(-,root,root,-)
@@ -229,11 +359,7 @@ rm -rf %{buildroot}
 %{_libdir}/mpich/share/cmake/*
 %{_libdir}/mpich/share/opm/cmake/Modules/*
 
-%files bin
-%{_bindir}/*
-
-%files openmpi-bin
-%{_libdir}/openmpi/bin/*
-
-%files mpich-bin
+%files mpich-bin%{opm_package_version}
 %{_libdir}/mpich/bin/*
+%{_libdir}/mpich/share/man/*
+%endif


### PR DESCRIPTION
- add parameter for which toolset to use
- build against openmpi3
- add boolean flags for the different mpi builds (mostly for testing)
- add parameter for appending extra token to package names.
  this can be used for allowing multiple versions to be installed on the
  same system.