### PR TITLE
remove stale reference from CMakeLists_files.txt

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -131,7 +131,6 @@ list (APPEND PROGRAM_SOURCE_FILES
   examples/upscale_perm.cpp
   examples/upscale_relperm.cpp
   examples/upscale_relpermvisc.cpp
-  examples/upscale_singlephase.cpp
   examples/upscale_steadystate_implicit.cpp
   examples/upscale_elasticity.cpp
 )


### PR DESCRIPTION
forgotten in 127850e3e79528156026ef23eef5dce353967ff0