### PR TITLE
Do not install steadystate_test_implicit.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -124,7 +124,6 @@ list (APPEND PROGRAM_SOURCE_FILES
   examples/cpregularize.cpp
   examples/exp_variogram.cpp
   examples/grdecldips.cpp
-  examples/steadystate_test_implicit.cpp
   examples/upscale_avg.cpp
   examples/upscale_cap.cpp
   examples/upscale_cond.cpp


### PR DESCRIPTION
It does not seem to be useful.

Not vital for 2022.10 but would still be good to have in there.

Closes #366