### PR TITLE
Chase Removal of HAVE_UMFPACK Preprocessor Symbol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,6 @@ macro (config_hook)
 	opm_need_version_of ("dune-istl")
 	list (APPEND ${project}_CONFIG_IMPL_VARS
 		HAVE_LAPACK
-		HAVE_UMFPACK
 		HAVE_SUPERLU
 		HAVE_SUITESPARSE_UMFPACK
 		)

--- a/opm/elasticity/elasticity_preconditioners.hpp
+++ b/opm/elasticity/elasticity_preconditioners.hpp
@@ -37,7 +37,7 @@
 namespace Opm {
 namespace Elasticity {
 
-#if defined(HAVE_UMFPACK)
+#if defined(HAVE_SUITESPARSE_UMFPACK)
 typedef Dune::UMFPack<Matrix> LUSolver;
 #elif defined(HAVE_SUPERLU)
 typedef Dune::SuperLU<Matrix> LUSolver;

--- a/opm/elasticity/elasticity_upscale_impl.hpp
+++ b/opm/elasticity/elasticity_upscale_impl.hpp
@@ -1054,7 +1054,7 @@ IMPL_FUNC(void, setupSolvers(const LinSolParams& params))
     if (B.N()) 
       A.getOperator() = MatrixOps::augment(A.getOperator(), B,
                                            0, A.getOperator().M(), true);
-#if HAVE_UMFPACK || HAVE_SUPERLU
+#if HAVE_SUITESPARSE_UMFPACK || HAVE_SUPERLU
     tsolver.push_back(SolverPtr(new LUSolver(A.getOperator(),
                                              verbose?2:(params.report?1:0))));
     for (int i=1;i<numsolvers;++i)


### PR DESCRIPTION
Following PR OPM/opm-common#4202 (commit OPM/opm-common@757a9538b) there is only `HAVE_SUITESPARSE_UMFPACK`.