### PR TITLE
fixed: parallel execution of relperm upscaling

### DIFF
--- a/compareUpscaling.cmake
+++ b/compareUpscaling.cmake
@@ -68,10 +68,14 @@ endmacro (add_test_upscale_perm)
 #   - rows: Number of rows in result file that is to be compared
 # This macro assumes that ${gridname}.grdecl is found in directory ${INPUT_DATA_PATH}grids/
 # and that upscale_perm_BC${bcs}_${gridname}.txt is found in ${INPUT_DATA_PATH}reference_solutions
-macro (add_test_upscale_relperm testname gridname stonefiles rows cols)
+macro (add_test_upscale_relperm testname gridname stonefiles rows cols nproc)
   # Add test that runs upscale_perm and outputs the results to file
   # Ensure unique output folder per test (because this folder is deleted in the test driver script)
-  set(TEST_NAME upscale_relperm_${testname})
+  if (${nproc} GREATER 1)
+    set(TEST_NAME upscale_relperm_${testname}_np${nproc})
+  else()
+    set(TEST_NAME upscale_relperm_${testname})
+  endif()
   set(RESULT_PATH ${BASE_RESULT_PATH}/${TEST_NAME})
   set(test_args ${ARGN}
                 -output ${RESULT_PATH}/upscale_relperm_${testname}.txt
@@ -87,7 +91,9 @@ macro (add_test_upscale_relperm testname gridname stonefiles rows cols)
                            -n upscale_relperm_${testname}
                            -a ${abstol}
                            -t ${reltol}
+                           -p ${nproc}
                TEST_ARGS ${test_args})
+  set_tests_properties(${TEST_NAME} PROPERTIES PROCESSORS ${nproc})
 endmacro ()
 
 ###########################################################################
@@ -162,7 +168,7 @@ add_test_upscale_perm(Hummocky flp 9)
 
 # Add tests for different models
 add_test_upscale_relperm(BCf_pts20_surfTens11_stonefile_benchmark_stonefile_benchmark_benchmark_tiny_grid
-                         benchmark_tiny_grid stonefile_benchmark.txt 20 8
+                         benchmark_tiny_grid stonefile_benchmark.txt 20 8 1
                          -bc f -points 20 -relPermCurve 2 -upscaleBothPhases true
                          -jFunctionCurve 3 -surfaceTension 11 -gravity 0.0
                          -waterDensity 1.0 -oilDensity 0.6 -interpolate 0
@@ -173,17 +179,24 @@ add_test_upscale_relperm(BCf_pts20_surfTens11_stonefile_benchmark_stonefile_benc
                          -krowxswirr -1 -krowyswirr -1 -krowzswirr -1
                          -doEclipseCheck true -critRelpermThresh 1e-6)
 add_test_upscale_relperm(BCf_pts30_surfTens11_stone1_stone1_EightCells
-                         EightCells stone1.txt 30 8)
+                         EightCells stone1.txt 30 8 1)
 add_test_upscale_relperm(BCf_pts20_surfTens11_stone1_stone1_EightCells
-                         EightCells stone1.txt 30 8 -points 20)
+                         EightCells stone1.txt 30 8 1 -points 20)
 add_test_upscale_relperm(BCl_pts30_surfTens11_stone1_stone1_EightCells
-                         EightCells stone1.txt 30 20 -bc l)
+                         EightCells stone1.txt 30 20 1 -bc l)
 add_test_upscale_relperm(BCf_pts30_surfTens45_stone1_stone1_EightCells
-                         EightCells stone1.txt 30 8 -surfaceTension 45)
+                         EightCells stone1.txt 30 8 1 -surfaceTension 45)
 add_test_upscale_relperm(BCf_pts30_surfTens11_stone1_stone2_EightCells
-                         EightCells "stone1.txt;stone2.txt" 30 8)
+                         EightCells "stone1.txt;stone2.txt" 30 8 1)
 add_test_upscale_relperm(BCf_pts30_surfTens11_stoneAniso_stoneAniso_27cellsAniso
-                         27cellsAniso stoneAniso.txt 30 8)
+                         27cellsAniso stoneAniso.txt 30 8 1)
+
+if(MPI_FOUND)
+add_test_upscale_relperm(BCf_pts30_surfTens11_stone1_stone1_EightCells
+                         EightCells stone1.txt 30 8 4)
+  add_test_upscale_relperm(BCf_pts30_surfTens11_stoneAniso_stoneAniso_27cellsAniso
+                           27cellsAniso stoneAniso.txt 30 8 4)
+endif()
 
 if((DUNE_ISTL_VERSION_MAJOR GREATER 2) OR
    (DUNE_ISTL_VERSION_MAJOR EQUAL 2 AND DUNE_ISTL_VERSION_MINOR GREATER 2))

--- a/opm/upscaling/UpscalerBase_impl.hpp
+++ b/opm/upscaling/UpscalerBase_impl.hpp
@@ -54,7 +54,8 @@ namespace Opm
 	  linsolver_verbosity_(0),
           linsolver_type_(3),
           linsolver_smooth_steps_(1),
-          gravity_(0.0)
+          gravity_(0.0),
+          grid_(MPI_COMM_SELF)
     {
     }
 

--- a/tests/run-compareUpscaling.sh
+++ b/tests/run-compareUpscaling.sh
@@ -12,11 +12,13 @@ then
   echo -e "\t\t -a <tol>      Absolute tolerance in comparison"
   echo -e "\t\t -t <tol>      Relative tolerance in comparison"
   echo -e "\t\t -e <filename> Simulator binary to use"
+  echo -e "\t\t -p <nproc > Number of processors to use"
   exit 1
 fi
 
 OPTIND=1
-while getopts "i:r:b:n:a:t:e:" OPT
+NPROC=1
+while getopts "i:r:b:n:a:t:e:p:" OPT
 do
   case "${OPT}" in
     i) INPUT_DATA_PATH=${OPTARG} ;;
@@ -26,6 +28,7 @@ do
     a) ABS_TOL=${OPTARG} ;;
     t) REL_TOL=${OPTARG} ;;
     e) EXE_NAME=${OPTARG} ;;
+    p) NPROC=${OPTARG} ;;
   esac
 done
 shift $(($OPTIND-1))
@@ -34,5 +37,10 @@ TEST_ARGS="$@"
 rm -Rf ${RESULT_PATH}
 mkdir -p ${RESULT_PATH}
 
-OMP_NUM_THREADS=1 ${BINPATH}/${EXE_NAME} ${TEST_ARGS}
+if test $NPROC -gt 1
+then
+  OMP_NUM_THREADS=1 mpirun -np ${NPROC} ${BINPATH}/${EXE_NAME} ${TEST_ARGS}
+else
+  OMP_NUM_THREADS=1 ${BINPATH}/${EXE_NAME} ${TEST_ARGS}
+fi
 ${BINPATH}/compareUpscaling ${INPUT_DATA_PATH}/reference_solutions/${TEST_NAME}.txt ${RESULT_PATH}/${TEST_NAME}.txt ${ABS_TOL} ${REL_TOL}


### PR DESCRIPTION
we need the grid on all processes, so pass MPI_COMM_SELF communicator to the grid instance

This probably broke a long time ago.