### PR TITLE
Prefer Std::Numbers::PI

### DIFF
--- a/examples/known_answer_test.cpp
+++ b/examples/known_answer_test.cpp
@@ -64,14 +64,15 @@
 
 #include <opm/upscaling/initCPGrid.hpp>
 
-
-
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <cmath>
 #include <iomanip>
 #include <iostream>
-
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 // ------------ Specifying the solution ------------
 

--- a/examples/known_answer_test.cpp
+++ b/examples/known_answer_test.cpp
@@ -70,6 +70,7 @@
 #include <cmath>
 #include <iomanip>
 #include <iostream>
+#include <numbers>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -82,13 +83,13 @@ namespace {
 
     double u(const Vec& x)
     {
-        const double pi = 3.14159265358979323846264338327950288;
+        constexpr auto pi = std::numbers::pi;
         return std::sin(2*pi*x[0]) * std::cos(2*pi*x[1]) * x[2];
     }
 
     double Lu(const Vec& x)
     {
-        const double pi = 3.14159265358979323846264338327950288;
+        constexpr auto pi = std::numbers::pi;
         return -2 * 2*pi * 2*pi * std::sin(2*pi*x[0]) * std::cos(2*pi*x[1]) * x[2];
     }
 

--- a/examples/upscale_elasticity.cpp
+++ b/examples/upscale_elasticity.cpp
@@ -40,8 +40,19 @@
 #include <opm/elasticity/elasticity_upscale.hpp>
 #include <opm/elasticity/matrixops.hpp>
 
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdio>
 #include <cstring>
+#include <ctime>
+#include <fstream>
 #include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 #include <unistd.h>
 
@@ -180,7 +191,7 @@ void parseCommandLine(int argc, char** argv, Params& p)
   p.verbose  = param.getDefault<bool>("verbose",false);
   p.outputSpeeds = param.getDefault<bool>("output_wave_speeds",false);
   p.inspect  = param.getDefault<std::string>("inspect","");
-  size_t i;
+  std::size_t i;
   if ((i=p.vtufile.find(".vtu")) != std::string::npos)
     p.vtufile = p.vtufile.substr(0,i);
 
@@ -221,7 +232,7 @@ void writeOutput(const Params& p, Opm::time::StopWatch& watch, int cells,
   f << "######################################################################" << std::endl
     << "# Results from upscaling elastic moduli." << std::endl
     << "#" << std::endl
-    << "# Finished: " << asctime(timeinfo)
+    << "# Finished: " << std::asctime(timeinfo)
     << "# Hostname: " << hostname << std::endl
     << "#" << std::endl
     << "# Upscaling time: " << watch.secsSinceStart() << " secs" << std::endl
@@ -253,11 +264,11 @@ void writeOutput(const Params& p, Opm::time::StopWatch& watch, int cells,
   f << "#" << std::endl;
   if (bySat) {
     f << "# SATNUM: " << volume.size() << std::endl;
-    for (size_t i=0;i<volume.size();++i)
+    for (std::size_t i=0;i<volume.size();++i)
       f << "#\t SATNUM " << i+1 << ": " << volume[i]*100 << "%" << std::endl;
   } else {
     f <<"# Materials: " << volume.size() << std::endl;
-    for (size_t i=0;i<volume.size();++i)
+    for (std::size_t i=0;i<volume.size();++i)
       f << "#\t Material" << i+1 << ": " << volume[i]*100 << "%" << std::endl;
   }
   if (upscaledRho > 0) {
@@ -316,7 +327,7 @@ int run(Params& p)
       double lz = p.max[2]-p.min[2];
       int nz = grid.logicalCartesianSize()[2];
       double hz = lz/nz;
-      double lp = sqrt((double)(p.max[0]-p.min[0])*(p.max[1]-p.min[1]));
+      double lp = std::sqrt((double)(p.max[0]-p.min[0])*(p.max[1]-p.min[1]));
       int np = std::max(grid.logicalCartesianSize()[0],
                         grid.logicalCartesianSize()[1]);
       double hp = lp/np;
@@ -334,7 +345,7 @@ int run(Params& p)
       double hx = (p.max[0]-p.min[0])/grid.logicalCartesianSize()[0];
       double hy = (p.max[1]-p.min[1])/grid.logicalCartesianSize()[1];
       double hz = (p.max[2]-p.min[2])/grid.logicalCartesianSize()[2];
-      double aspect = sqrt(hx*hy)/hz;
+      double aspect = std::sqrt(hx*hy)/hz;
       std::cout << "Estimated cell aspect ratio: " << aspect;
       if (aspect > 80) {
         p.linsolver.pre = TWOLEVEL;
@@ -383,27 +394,27 @@ int run(Params& p)
       std::cout << "processing case " << i+1 << "..." << std::endl;
       if (p.inspect == "results") {
         char temp[1024];
-        sprintf(temp, p.resultfilename.c_str(), "x", i+1);
+        std::snprintf(temp, std::size(temp), p.resultfilename.c_str(), "x", i+1);
         Dune::loadMatrixMarket(upscale.u[i], temp);
       } else {
         std::cout << "\tassembling load vector..." << std::endl;
         upscale.assemble(i,false);
         if (p.inspect == "load") {
           char temp[1024];
-          sprintf(temp, p.resultfilename.c_str(), "b", i+1);
+          std::snprintf(temp, std::size(temp), p.resultfilename.c_str(), "b", i+1);
           Dune::storeMatrixMarket(upscale.b[i], temp);
         }
         std::cout << "\tsolving..." << std::endl;
         upscale.solve(i);
         if (p.inspect == "load") {
           char temp[1024];
-          sprintf(temp, p.resultfilename.c_str(), "x", i+1);
+          std::snprintf(temp, std::size(temp), p.resultfilename.c_str(), "x", i+1);
           Dune::storeMatrixMarket(upscale.u[i], temp);
         }
       }
       upscale.A.expandSolution(field[i],upscale.u[i]);
 #define CLAMP(x) (fabs(x)<1.e-4?0.0:x)
-      for (size_t j=0;j<field[i].size();++j) {
+      for (std::size_t j=0;j<field[i].size();++j) {
         double val = field[i][j];
         field[i][j] = CLAMP(val);
       }
@@ -470,9 +481,9 @@ int main(int argc, char** argv)
 try
 {
   try {
-    if (argc < 2 || strcmp(argv[1],"-h") == 0
-                 || strcmp(argv[1],"--help") == 0
-                 || strcmp(argv[1],"-?") == 0) {
+    if (argc < 2 || std::strcmp(argv[1],"-h") == 0
+                 || std::strcmp(argv[1],"--help") == 0
+                 || std::strcmp(argv[1],"-?") == 0) {
       syntax(argv);
       exit(1);
     }

--- a/examples/upscale_elasticity.cpp
+++ b/examples/upscale_elasticity.cpp
@@ -49,6 +49,7 @@
 #include <ctime>
 #include <fstream>
 #include <iostream>
+#include <numbers>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -57,10 +58,6 @@
 #include <unistd.h>
 
 using namespace Opm::Elasticity;
-
-#ifndef M_PI
-#define M_PI std::acos(-1.0)
-#endif
 
 //! \brief Display the available command line parameters
 void syntax(char** argv)
@@ -176,7 +173,7 @@ void parseCommandLine(int argc, char** argv, Params& p)
   if (method == "none")
     p.method = UPSCALE_NONE;
   p.Emin     = param.getDefault<double>("Emin",0.0);
-  p.dip      = param.getDefault<double>("dip_angle", M_PI/2);
+  p.dip      = param.getDefault<double>("dip_angle", std::numbers::pi/2);
   p.azimuth  = param.getDefault<double>("azimuth_angle", 0.0);
   p.ctol     = param.getDefault<double>("ctol",1.e-6);
 #ifndef HAVE_OLD_CPGRID_API

--- a/opm/elasticity/boundarygrid.cpp
+++ b/opm/elasticity/boundarygrid.cpp
@@ -20,6 +20,7 @@
 #include <cmath>
 #include <cstddef>
 #include <iostream>
+#include <numbers>
 #include <vector>
 
 namespace Opm {
@@ -281,8 +282,8 @@ bool BoundaryGrid::cubicSolve(double eps, double A, double B, double C,
     if (W <= -epsmall && P < 0) {
       double FI = acos(-Q/sqrt(-P*P*P));
       X.push_back( 2*std::sqrt(-P)*std::cos(FI/3));
-      X.push_back(-2*std::sqrt(-P)*std::cos((FI+M_PI)/3));
-      X.push_back(-2*std::sqrt(-P)*std::cos((FI-M_PI)/3));
+      X.push_back(-2*std::sqrt(-P)*std::cos((FI+std::numbers::pi)/3));
+      X.push_back(-2*std::sqrt(-P)*std::cos((FI-std::numbers::pi)/3));
     } else if (std::fabs(W) < epsmall && Q < 0) {
       X.push_back(2*std::pow(-Q,1.f/3));
       X.push_back(-.5f*X[0]);

--- a/opm/elasticity/boundarygrid.cpp
+++ b/opm/elasticity/boundarygrid.cpp
@@ -15,8 +15,12 @@
 
 #include "boundarygrid.hh"
 
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
 #include <iostream>
-
+#include <vector>
 
 namespace Opm {
 namespace Elasticity {
@@ -181,7 +185,7 @@ int BoundaryGrid::Q4inv(FaceCoord& res, const Quad& q,
   // check that obtained solutions are inside element
   double tol = 1+epsOut;
   int nInside=0;
-  for (size_t i=0;i<xi.size();++i) {
+  for (std::size_t i=0;i<xi.size();++i) {
     if (xi[i] < tol && eta[i] < tol) {
       if (++nInside > 1) {
         std::cout << "multiple solutions" << std::endl;
@@ -217,17 +221,17 @@ bool BoundaryGrid::bilinearSolve(double epsilon, double order,
   double tol = 0;
   // geometric tolerance ?
   for (int i=0;i<4;++i) {
-    double det = fabs(A[i]);
+    double det = std::fabs(A[i]);
     if (det > tol) tol = det;
-    det = fabs(B[i]);
+    det = std::fabs(B[i]);
     if (det > tol) tol = det;
   }
   tol *= epsilon;
 
   double det = A[1]*B[2]-B[1]*A[2];
-  if (fabs(A[0]) < tol && fabs(B[0]) < tol) {
+  if (std::fabs(A[0]) < tol && std::fabs(B[0]) < tol) {
     // linear eqs
-    if (fabs(det) < tol*tol) return false;
+    if (std::fabs(det) < tol*tol) return false;
     X.push_back((B[2]*A[3]-A[2]*B[3])/det);
     Y.push_back((-B[1]*A[3]+A[1]*B[3])/det);
     return true;
@@ -238,9 +242,9 @@ bool BoundaryGrid::bilinearSolve(double epsilon, double order,
   double Q2 = A[0]*B[1]-B[0]*A[1];
   std::vector<double> Z;
   cubicSolve(epsilon,0,Q2,Q1,Q0,Z);
-  for (size_t i=0;i<Z.size();++i) {
+  for (std::size_t i=0;i<Z.size();++i) {
     Q0 = A[0]*Z[i]+A[2];
-    if (fabs(Q0) > tol) {
+    if (std::fabs(Q0) > tol) {
       X.push_back(Z[i]);
       Y.push_back((A[3]-A[1]*Z[i])/Q0);
     }
@@ -250,12 +254,12 @@ bool BoundaryGrid::bilinearSolve(double epsilon, double order,
   Q2 = A[0]*B[2]-B[0]*A[2];
   Z.clear();
   cubicSolve(epsilon,0,Q2,Q1,Q0,Z);
-  for (size_t i=0;i<Z.size();++i) {
+  for (std::size_t i=0;i<Z.size();++i) {
     Q0 = A[0]*Z[i]+A[1];
-    if (fabs(Q0) > tol) {
-      size_t j=0;
+    if (std::fabs(Q0) > tol) {
+      std::size_t j=0;
       for (j=0;j<Y.size();++j)
-        if (fabs(Y[j]-Z[i]) <= epsilon*order) break;
+        if (std::fabs(Y[j]-Z[i]) <= epsilon*order) break;
       if (j == Y.size()) {
         X.push_back((A[3]-A[2]*Z[i])/Q0);
         Y.push_back(Z[i]);
@@ -269,31 +273,31 @@ bool BoundaryGrid::bilinearSolve(double epsilon, double order,
 bool BoundaryGrid::cubicSolve(double eps, double A, double B, double C,
                               double D, std::vector<double>& X) const
 {
-  if (fabs(A) > eps) { // cubic
+  if (std::fabs(A) > eps) { // cubic
     double epsmall = pow(eps,6.f);
     double P = (C-B*B/(3*A))/(3*A);
     double Q = ((2*B*B/(27*A)-C/3)*B/A+D)/(2*A);
     double W = Q*Q+P*P*P;
     if (W <= -epsmall && P < 0) {
       double FI = acos(-Q/sqrt(-P*P*P));
-      X.push_back( 2*sqrt(-P)*cos(FI/3));
-      X.push_back(-2*sqrt(-P)*cos((FI+M_PI)/3));
-      X.push_back(-2*sqrt(-P)*cos((FI-M_PI)/3));
-    } else if (fabs(W) < epsmall && Q < 0) {
-      X.push_back(2*pow(-Q,1.f/3));
+      X.push_back( 2*std::sqrt(-P)*std::cos(FI/3));
+      X.push_back(-2*std::sqrt(-P)*std::cos((FI+M_PI)/3));
+      X.push_back(-2*std::sqrt(-P)*std::cos((FI-M_PI)/3));
+    } else if (std::fabs(W) < epsmall && Q < 0) {
+      X.push_back(2*std::pow(-Q,1.f/3));
       X.push_back(-.5f*X[0]);
       X.push_back(X[1]);
-    } else if (W > -epsmall && Q+sqrt(W) < 0 && Q-sqrt(W) < 0) {
-      X.push_back(pow(-Q+sqrt(W),1.f/3)+pow(-Q-sqrt(W),1.f/3));
+    } else if (W > -epsmall && Q+std::sqrt(W) < 0 && Q-std::sqrt(W) < 0) {
+      X.push_back(pow(-Q+std::sqrt(W),1.f/3)+std::pow(-Q-std::sqrt(W),1.f/3));
       X.push_back(-.5f*X[0]);
       X.push_back(X[1]);
-    } else if (W >= epsmall && fabs(Q) > epsmall && P > 0) {
-      double FI = atan(sqrt(P*P*P)/Q);
-      double KI = atan(pow(tan(.5f*FI),1.f/3));
-      X.push_back(-2*sqrt(P)/tan(KI+KI));
+    } else if (W >= epsmall && std::fabs(Q) > epsmall && P > 0) {
+      double FI = std::atan(std::sqrt(P*P*P)/Q);
+      double KI = std::atan(std::pow(tan(.5f*FI),1.f/3));
+      X.push_back(-2*std::sqrt(P)/std::tan(KI+KI));
       X.push_back(-.5f*X[0]);
       X.push_back(X[1]);
-    } else if (W > -epsmall && fabs(Q) > epsmall && P < 0)
+    } else if (W > -epsmall && std::fabs(Q) > epsmall && P < 0)
       return false;
     else
       return false;
@@ -304,11 +308,11 @@ bool BoundaryGrid::cubicSolve(double eps, double A, double B, double C,
     X[2] -= W;
 
     return true;
-  } else if (fabs(B) > eps) {
-    double epsmall = pow(eps,4.f);
+  } else if (std::fabs(B) > eps) {
+    double epsmall = std::pow(eps,4.f);
     double P = C*C-4*B*D;
     if (P > 0) {
-      double Q = sqrt(P);
+      double Q = std::sqrt(P);
       X.push_back((-C+Q)/(B+B));
       X.push_back((-C-Q)/(B+B));
     } else if (P > -epsmall) {
@@ -317,7 +321,7 @@ bool BoundaryGrid::cubicSolve(double eps, double A, double B, double C,
     }
     else
       return false;
-  } else if (fabs(C) > eps) {
+  } else if (std::fabs(C) > eps) {
     X.push_back(-D/C);
   } else
     return false;

--- a/opm/porsol/common/BoundaryPeriodicity.hpp
+++ b/opm/porsol/common/BoundaryPeriodicity.hpp
@@ -20,14 +20,14 @@
 #ifndef OPM_BOUNDARYPERIODICITY_HEADER_INCLUDED
 #define OPM_BOUNDARYPERIODICITY_HEADER_INCLUDED
 
-
 #include <dune/common/fvector.hh>
-#include <array>
+
 #include <opm/common/ErrorMacros.hpp>
 
 #include <algorithm>
-#include <vector>
+#include <array>
 #include <iostream>
+#include <vector>
 
 namespace Opm
 {

--- a/opm/porsol/common/BoundaryPeriodicity.hpp
+++ b/opm/porsol/common/BoundaryPeriodicity.hpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <array>
 #include <iostream>
+#include <numbers>
 #include <vector>
 
 namespace Opm
@@ -65,11 +66,11 @@ namespace Opm
 	}
 
     private:
-	double cmpval() const
-	{
-            const double pi = 3.14159265358979323846264338327950288;
-	    return centroid[(canon_pos/2 + 1)%3] + pi*centroid[(canon_pos/2 + 2)%3];
-	}
+        double cmpval() const
+        {
+            return centroid[(canon_pos/2 + 1)%3]
+                +  std::numbers::pi*centroid[(canon_pos/2 + 2)%3];
+        }
     };
 
 


### PR DESCRIPTION
We have C++20 now and can use the portable alternative to spelling  out the value or using the Posix-only `M_PI` macro.

While here, also include requisite headers and get symbols from the `std` namespace instead of the global namespace.