### PR TITLE
HAVE_SUITESPARSE_UMFPACK: this is now a property of the target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,6 @@ macro(opm-upscaling_prereqs_hook)
   endif()
   if(TARGET SuiteSparse::UMFPACK)
     target_link_libraries(opmupscaling PUBLIC SuiteSparse::UMFPACK)
-    target_compile_definitions(opmupscaling PUBLIC HAVE_SUITESPARSE_UMFPACK=1)
   endif()
 endmacro()
 


### PR DESCRIPTION
Downstream of https://github.com/OPM/opm-common/pull/5075