### PR TITLE
fixed: missing .* in absolute revision jenkins re

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -12,7 +12,7 @@ if grep -q "opm-common=" <<< $ghprbCommentBody
 then
     if test -n "$absolute_revisions"
     then
-        upstreamRev[opm-common]=$(echo $ghprbCommentBody | sed -r 's/.*opm-common=([^ ]+)/\1/g')
+        upstreamRev[opm-common]=$(echo $ghprbCommentBody | sed -r 's/.*opm-common=([^ ]+).*/\1/g')
     else
         upstreamRev[opm-common]=pull/$(echo $ghprbCommentBody | sed -r 's/.*opm-common=([0-9]+).*/\1/g')/merge
     fi


### PR DESCRIPTION
Mostly used in ci builder tests.