### PR TITLE
[cmake] Recover sibling builds supporting DUNE in build tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,10 @@ macro(opm-upscaling_install_hook)
   )
 endmacro()
 
+# These modules are special because they search with the first
+# find_package call in here
+set(initial_depends opm-common dune-common)
+
 if(SIBLING_SEARCH AND NOT opm-common_DIR)
   # guess the sibling dir
   get_filename_component(_leaf_dir_name ${PROJECT_BINARY_DIR} NAME)
@@ -98,28 +102,28 @@ if(SIBLING_SEARCH AND NOT opm-common_DIR)
   get_filename_component(_parent_dir_name ${_parent_full_dir} NAME)
   #Try if <module-name>/<build-dir> is used
   get_filename_component(_modules_dir ${_parent_full_dir} DIRECTORY)
-  if(IS_DIRECTORY ${_modules_dir}/opm-common/${_leaf_dir_name})
-    set(opm-common_DIR ${_modules_dir}/opm-common/${_leaf_dir_name})
-    set(opm-grid_DIR ${_modules_dir}/opm-grid/${_leaf_dir_name})
-  else()
-    string(REPLACE ${PROJECT_NAME} opm-common _opm_common_leaf ${_leaf_dir_name})
-    if(NOT _leaf_dir_name STREQUAL _opm_common_leaf
-        AND IS_DIRECTORY ${_parent_full_dir}/${_opm_common_leaf})
-      # We are using build directories named <prefix><module-name><postfix>
-      set(opm-common_DIR ${_parent_full_dir}/${_opm_common_leaf})
-      string(REPLACE ${PROJECT_NAME} opm-grid _opm_grid_leaf ${_leaf_dir_name})
-      set(opm-grid_DIR ${_parent_full_dir}/${_opm_grid_leaf})
-    elseif(IS_DIRECTORY ${_parent_full_dir}/opm-common)
-      # All modules are in a common build dir
-      set(opm-common_DIR "${_parent_full_dir}/opm-common")
-      set(opm-grid_DIR "${_parent_full_dir}/opm-grid")
+  foreach(module ${initial_depends})
+    if(IS_DIRECTORY ${_modules_dir}/${module}/${_leaf_dir_name})
+      set(${module}_DIR ${_modules_dir}/${module}/${_leaf_dir_name})
+    else()
+      string(REPLACE ${PROJECT_NAME} ${module} _module_leaf ${_leaf_dir_name})
+      if(NOT _leaf_dir_name STREQUAL _module_leaf
+          AND IS_DIRECTORY ${_parent_full_dir}/${_module_leaf})
+        # We are using build directories named <prefix><module-name><postfix>
+        set(${module}_DIR ${_parent_full_dir}/${_module_leaf})
+      elseif(IS_DIRECTORY ${_parent_full_dir}/${module})
+        # All modules are in a common build dir
+        set(${module}_DIR "${_parent_full_dir}/${module}")
+      endif()
     endif()
+  endforeach()
+endif()
+foreach(module ${initial_depends})
+  if(${module}_DIR AND NOT IS_DIRECTORY ${${module}_DIR})
+    message(WARNING "Value ${${module}_DIR} passed to variable"
+      " ${module}_DIR is not a directory")
   endif()
-endif()
-if(opm-common_DIR AND NOT IS_DIRECTORY ${opm-common_DIR})
-  message(WARNING "Value ${opm-common_DIR} passed to variable"
-    " opm-common_DIR is not a directory")
-endif()
+endforeach()
 
 find_package(opm-common REQUIRED)
 

--- a/dune.module
+++ b/dune.module
@@ -10,4 +10,8 @@ Label: 2026.10-pre
 Maintainer: arne.morten.kvarving@sintef.no
 MaintainerName: Arne Morten Kvarving
 Url: http://opm-project.org
-Depends: dune-common (>= 2.9) dune-grid (>= 2.9) dune-istl (>= 2.9) opm-common opm-grid
+# We need the full list of dependencies below, because we need to set
+# *_DIR for each of them when doing a sibling build (done using
+# CMakeLists.txt and cmake/Module/OpmSiblingSearch.cmake).
+Depends: dune-common (>= 2.9) dune-geometry (>=2.9) dune-grid (>= 2.9) dune-istl (>= 2.9) opm-common opm-grid
+Suggests: dune-uggrid (>= 2.9)


### PR DESCRIPTION
This was broken by the build system refactoring and the build system always picked up the DUNE version that was installed on the system even for activated

To recover it we need to construct a FULL chain of all DUNE modules that we might depend on. This has to be specified in dune.module currently. This list is constructed in cmake/Modules/OpmInit.cmake.

Note that both opm-common_DIR and dune-common_DIR need to be set in each module's toplevel CMakeLists.txt file because the are needed for the initial find_package(opm-common) call there which happens before including cmake/Modules/OpmInit.cmake

Needs OPM/opm-common#5130 and OPM/opm-grid#1030